### PR TITLE
Fix: Get metadata using the cache dir as first method

### DIFF
--- a/tcm/triton_cache_manager/data/cache_repo.py
+++ b/tcm/triton_cache_manager/data/cache_repo.py
@@ -82,7 +82,27 @@ class CacheRepository:
 
             for key, path_str in child_paths.items():
                 if key.endswith(".json"):
+                    # Try to get the json from the same path as the grp file first
+                    # This will fix an issue that occurs when we try to index Cache
+                    # from a container or a different host
+                    path_split = path_str.split("/")
+                    cache_key = path_split[len(path_split) - 2]
+                    kernel_name = path_split[len(path_split) - 1]
+                    metadata_path_str = f"{self.root}/{cache_key}/{kernel_name}"
+
+                    candidate_actual_meta_path = Path(metadata_path_str)
+
+                    if candidate_actual_meta_path.is_file():
+                        log.debug(
+                            "Derived actual metadata path %s in the same group file dir %s.",
+                            candidate_actual_meta_path,
+                            self.root,
+                        )
+                        return candidate_actual_meta_path
+
+                    # Second attempt, get the metadata dir from the group file
                     candidate_actual_meta_path = Path(path_str)
+
                     if candidate_actual_meta_path.is_file():
                         log.debug(
                             "Derived actual metadata path %s from group file '%s' using key '%s'.",

--- a/tcm/triton_cache_manager/data/cache_repo.py
+++ b/tcm/triton_cache_manager/data/cache_repo.py
@@ -85,14 +85,20 @@ class CacheRepository:
                     # Try to get the json from the same path as the grp file first
                     # This will fix an issue that occurs when we try to index Cache
                     # from a container or a different host
-                    path_split = path_str.split("/")
-                    cache_key = path_split[len(path_split) - 2]
-                    kernel_name = path_split[len(path_split) - 1]
-                    metadata_path_str = f"{self.root}/{cache_key}/{kernel_name}"
+                    candidate_actual_meta_path = None
 
-                    candidate_actual_meta_path = Path(metadata_path_str)
+                    path = Path(path_str)
+                    if path.parent.name and path.name:
+                        cache_key = path.parent.name
+                        kernel_name = path.name
+                        metadata_path_str = self.root / cache_key / kernel_name
 
-                    if candidate_actual_meta_path.is_file():
+                        candidate_actual_meta_path = Path(metadata_path_str)
+
+                    if (
+                        candidate_actual_meta_path is not None
+                        and candidate_actual_meta_path.is_file()
+                    ):
                         log.debug(
                             "Derived actual metadata path %s in the same group file dir %s.",
                             candidate_actual_meta_path,

--- a/tcm/triton_cache_manager/data/cache_repo.py
+++ b/tcm/triton_cache_manager/data/cache_repo.py
@@ -102,7 +102,7 @@ class CacheRepository:
                         log.debug(
                             "Derived actual metadata path %s in the same group file dir %s.",
                             candidate_actual_meta_path,
-                            self.root,
+                            path.parent,
                         )
                         return candidate_actual_meta_path
 


### PR DESCRIPTION
it will fallback to the previous method
This will fix indexing the cache when the cache is not generated from the host itself