### PR TITLE
tcm : add cache hit on criteria

### DIFF
--- a/tcm/triton_cache_manager/cli/main.py
+++ b/tcm/triton_cache_manager/cli/main.py
@@ -240,7 +240,7 @@ def search(
                 )
 
 
-# pylint: disable=too-many-positional-arguments
+# pylint: disable=too-many-positional-arguments, too-many-locals
 @app.command()
 def prune(  # pylint: disable=too-many-arguments
     name: Optional[str] = typer.Option(
@@ -296,7 +296,7 @@ def prune(  # pylint: disable=too-many-arguments
     if not check_hits_num(cache_hit_higher, cache_hit_lower):
         rich.print("[red]Lower cache hit cannot be higher than higher cache hit[/red]")
         return
- 
+
     svc = None
     try:
         svc = PruningService(cache_dir=cache_dir)

--- a/tcm/triton_cache_manager/cli/main.py
+++ b/tcm/triton_cache_manager/cli/main.py
@@ -200,7 +200,7 @@ def search(
         rich.print("[red]DB was not found. Have you used `tcm index` first?[/red]")
         return
     if not check_hits_num(cache_hit_higher, cache_hit_lower):
-        rich.print("[red]Higher cache hit cannot be lower than lower cache hit[/red]")
+        rich.print("[red]Error: --cache-hit-lower cannot be greater than --cache-hit-higher[/red]")
         return
 
     older_younger = get_older_younger(older_than, younger_than)
@@ -294,7 +294,7 @@ def prune(  # pylint: disable=too-many-arguments
         rich.print("[red]DB was not found. Have you used `tcm index` first?[/red]")
         return
     if not check_hits_num(cache_hit_higher, cache_hit_lower):
-        rich.print("[red]Lower cache hit cannot be higher than higher cache hit[/red]")
+        rich.print("[red]Error: --cache-hit-lower cannot be greater than --cache-hit-higher[/red]")
         return
 
     svc = None

--- a/tcm/triton_cache_manager/cli/main.py
+++ b/tcm/triton_cache_manager/cli/main.py
@@ -136,7 +136,7 @@ def _display_kernels_table(rows: List[Dict[str, Any]]):
         total_size_str = format_size(total_size_bytes)
         last_time_unix = row_dict.get("last_access")
         last_time_str = mod_time_handle(last_time_unix)
-        num_hits = row_dict.get("runtime_hits",0)
+        num_hits = row_dict.get("runtime_hits", 0)
         num_hits_str = str(num_hits)
         table.add_row(
             row_dict.get("hash", "N/A")[:12] + "...",
@@ -152,6 +152,7 @@ def _display_kernels_table(rows: List[Dict[str, Any]]):
         )
 
     rich.print(table)
+
 
 # pylint: disable=too-many-positional-arguments
 # pylint: disable=too-many-arguments
@@ -176,6 +177,16 @@ def search(
         "--younger-than",
         help="Show kernels younger than specified duration (e.g., '14d', '1w').",
     ),
+    cache_hit_lower: Optional[int] = typer.Option(
+        None,
+        "--",
+        help="Show kernels with cache hits lower than specified number (e.g., '1', '10').",
+    ),
+    cache_hit_higher: Optional[int] = typer.Option(
+        None,
+        "--",
+        help="Show kernels with cache hits higher than specified number (e.g., '1', '10').",
+    ),
     cache_dir: Optional[Path] = typer.Option(
         None,
         help="Specify the Triton cache directory to index. Uses default if not provided.",
@@ -197,6 +208,8 @@ def search(
         arch=arch,
         older_than_timestamp=older_younger[0],
         younger_than_timestamp=older_younger[1],
+        cache_hit_lower=cache_hit_lower,
+        cache_hit_higher=cache_hit_higher,
     )
 
     svc = None
@@ -245,6 +258,16 @@ def prune(  # pylint: disable=too-many-arguments
         "--younger-than",
         help="Show kernels younger than specified duration (e.g., '14d', '1w').",
     ),
+    cache_hit_lower: Optional[int] = typer.Option(
+        None,
+        "--",
+        help="Show kernels with cache hits lower than specified number (e.g., '1', '10').",
+    ),
+    cache_hit_higher: Optional[int] = typer.Option(
+        None,
+        "--",
+        help="Show kernels with cache hits higher than specified number (e.g., '1', '10').",
+    ),
     full: bool = typer.Option(
         False, "--full", help="Remove the entire kernel directory."
     ),
@@ -289,6 +312,8 @@ def prune(  # pylint: disable=too-many-arguments
                 arch=arch,
                 older_than_timestamp=older_younger[0],
                 younger_than_timestamp=older_younger[1],
+                cache_hit_higher=cache_hit_higher,
+                cache_hit_lower=cache_hit_lower,
             )
             stats = svc.prune(
                 criteria,

--- a/tcm/triton_cache_manager/cli/main.py
+++ b/tcm/triton_cache_manager/cli/main.py
@@ -18,6 +18,7 @@ from ..utils.utils import (
     format_size,
     mod_time_handle,
     get_older_younger,
+    check_hits_num,
 )
 from ..models.criteria import SearchCriteria
 from ..services.prune import PruningService, PruneStats
@@ -179,12 +180,12 @@ def search(
     ),
     cache_hit_lower: Optional[int] = typer.Option(
         None,
-        "--",
+        "--cache-hit-lower",
         help="Show kernels with cache hits lower than specified number (e.g., '1', '10').",
     ),
     cache_hit_higher: Optional[int] = typer.Option(
         None,
-        "--",
+        "--cache-hit-higher",
         help="Show kernels with cache hits higher than specified number (e.g., '1', '10').",
     ),
     cache_dir: Optional[Path] = typer.Option(
@@ -197,6 +198,9 @@ def search(
     """
     if not _cache_db_exists():
         rich.print("[red]DB was not found. Have you used `tcm index` first?[/red]")
+        return
+    if not check_hits_num(cache_hit_higher, cache_hit_lower):
+        rich.print("[red]Higher cache hit cannot be lower than lower cache hit[/red]")
         return
 
     older_younger = get_older_younger(older_than, younger_than)
@@ -260,12 +264,12 @@ def prune(  # pylint: disable=too-many-arguments
     ),
     cache_hit_lower: Optional[int] = typer.Option(
         None,
-        "--",
+        "--cache-hit-lower",
         help="Show kernels with cache hits lower than specified number (e.g., '1', '10').",
     ),
     cache_hit_higher: Optional[int] = typer.Option(
         None,
-        "--",
+        "--cache-hit-higher",
         help="Show kernels with cache hits higher than specified number (e.g., '1', '10').",
     ),
     full: bool = typer.Option(
@@ -289,7 +293,10 @@ def prune(  # pylint: disable=too-many-arguments
     if not _cache_db_exists():
         rich.print("[red]DB was not found. Have you used `tcm index` first?[/red]")
         return
-
+    if not check_hits_num(cache_hit_higher, cache_hit_lower):
+        rich.print("[red]Lower cache hit cannot be higher than higher cache hit[/red]")
+        return
+ 
     svc = None
     try:
         svc = PruningService(cache_dir=cache_dir)

--- a/tcm/triton_cache_manager/data/database.py
+++ b/tcm/triton_cache_manager/data/database.py
@@ -125,6 +125,13 @@ class Database:
                         value = transformer(value)
                     active_filters.append(orm_column == value)
 
+            if criteria.cache_hit_lower is not None:
+                active_filters.append(KernelOrm.runtime_hits < criteria.cache_hit_lower)
+
+            if criteria.cache_hit_higher is not None:
+                active_filters.append(
+                    KernelOrm.runtime_hits > criteria.cache_hit_higher
+                )
             if criteria.older_than_timestamp is not None:
                 active_filters.append(
                     KernelOrm.modified_time < criteria.older_than_timestamp

--- a/tcm/triton_cache_manager/models/criteria.py
+++ b/tcm/triton_cache_manager/models/criteria.py
@@ -17,3 +17,5 @@ class SearchCriteria:
     arch: Optional[str] = None
     older_than_timestamp: Optional[float] = None
     younger_than_timestamp: Optional[float] = None
+    cache_hit_lower: Optional[int] = None
+    cache_hit_higher: Optional[int] = None

--- a/tcm/triton_cache_manager/models/criteria.py
+++ b/tcm/triton_cache_manager/models/criteria.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
-
+# pylint: disable=too-many-instance-attributes
 @dataclass
 class SearchCriteria:
     """Data structure to hold kernel search filter criteria."""

--- a/tcm/triton_cache_manager/utils/utils.py
+++ b/tcm/triton_cache_manager/utils/utils.py
@@ -116,3 +116,10 @@ def get_older_younger(
         )
         raise typer.Exit(1)
     return older_than_timestamp, younger_than_timestamp
+
+def check_hits_num(higher: int | None, lower: int | None) -> bool:
+    """Check if higher is less than lower"""
+    if higher is not None and lower is not None:
+        if higher > lower:
+            return False
+    return True

--- a/tcm/triton_cache_manager/utils/utils.py
+++ b/tcm/triton_cache_manager/utils/utils.py
@@ -8,6 +8,7 @@ from typing import Optional, Tuple
 import rich
 import typer
 
+
 def format_size(size_bytes: int | float) -> str:
     """
     Format a file size in a human-readable way.
@@ -117,8 +118,9 @@ def get_older_younger(
         raise typer.Exit(1)
     return older_than_timestamp, younger_than_timestamp
 
+
 def check_hits_num(higher: int | None, lower: int | None) -> bool:
-    """Check if higher is less than lower"""
+    """Check if cache hit bounds are valid (higher should not be greater than lower)."""
     if higher is not None and lower is not None:
         if higher > lower:
             return False


### PR DESCRIPTION
added cache hit on criteria usable for prune and search operations. A new test for this has been implemented in the prune service.