### PR TITLE
tcm : remove cache miss on tracker

### DIFF
--- a/tcm/triton_cache_manager/tests/runtime/test_collector.py
+++ b/tcm/triton_cache_manager/tests/runtime/test_collector.py
@@ -29,9 +29,8 @@ def test_updates_kernel(fake_kernel, mock_session):
     collector.record_access("abcd1234", hit=False)
     collector.flush()
 
-    # the fake KernelOrm instance should now show 1 hit / 1 miss
+    # the fake KernelOrm instance should now show 1 hit
     assert fake_kernel.runtime_hits == 1
-    assert fake_kernel.runtime_misses == 1
     assert fake_kernel.last_access_time > 0
     assert mock_session.commit.call_count == 2
 
@@ -71,7 +70,7 @@ def test_data_persistence_with_multiple_records():
     """
     Tests that the collector correctly aggregates multiple records
     and that the flush method attempts to write the correct,
-    aggregated hit/miss to the database
+    aggregated hit to the database
     """
 
     mock_db = MagicMock()
@@ -83,12 +82,10 @@ def test_data_persistence_with_multiple_records():
 
     mock_kernel1 = MagicMock()
     mock_kernel1.runtime_hits = 0
-    mock_kernel1.runtime_misses = 0
     mock_kernel1.last_access_time = None
 
     mock_kernel2 = MagicMock()
     mock_kernel2.runtime_hits = 5
-    mock_kernel2.runtime_misses = 2
     mock_kernel2.last_access_time = None
 
     mock_session.query.side_effect = create_query_side_effect(
@@ -121,14 +118,12 @@ def test_data_persistence_with_multiple_records():
 
         assert mock_db.get_session.called
 
-        # For key1: 0 + 2 hits, 0 + 1 miss
+        # For key1: 0 + 2 hits
         assert mock_kernel1.runtime_hits == 2
-        assert mock_kernel1.runtime_misses == 1
         assert mock_kernel1.last_access_time > 0
 
-        # For key2: 5 + 1 hit, 2 + 2 misses
+        # For key2: 5 + 1 hit, 2 
         assert mock_kernel2.runtime_hits == 6
-        assert mock_kernel2.runtime_misses == 4
         assert mock_kernel2.last_access_time > 0
 
         mock_session.commit.assert_called_once()

--- a/tcm/triton_cache_manager/tests/runtime/test_collector.py
+++ b/tcm/triton_cache_manager/tests/runtime/test_collector.py
@@ -37,6 +37,7 @@ def test_updates_kernel(fake_kernel, mock_session):
 
 def create_query_side_effect(mock_kernel1, mock_kernel2):
     """Helper function for query side effect"""
+
     # pylint: disable=unused-argument
     def query_side_effect(model):
         query_mock = MagicMock()
@@ -122,7 +123,7 @@ def test_data_persistence_with_multiple_records():
         assert mock_kernel1.runtime_hits == 2
         assert mock_kernel1.last_access_time > 0
 
-        # For key2: 5 + 1 hit, 2 
+        # For key2: 5 + 1 hit, 2
         assert mock_kernel2.runtime_hits == 6
         assert mock_kernel2.last_access_time > 0
 

--- a/tcm/triton_cache_manager/tests/runtime/test_tracker.py
+++ b/tcm/triton_cache_manager/tests/runtime/test_tracker.py
@@ -42,8 +42,8 @@ def stub_file_cache_manager(monkeypatch):
     return Dummy
 
 # pylint: disable=unused-argument, redefined-outer-name
-def test_hit_and_miss_are_recorded(monkeypatch, stub_file_cache_manager, fake_kernel):
-    """Test cache hit/miss"""
+def test_hit_is_recorded(monkeypatch, stub_file_cache_manager, fake_kernel):
+    """Test cache hit"""
     # fresh collector instance, inserted into module under test
     fresh_collector = tr.RuntimeStatsCollector()
     monkeypatch.setattr(tr, "_runtime_collector", fresh_collector, raising=True)
@@ -55,6 +55,5 @@ def test_hit_and_miss_are_recorded(monkeypatch, stub_file_cache_manager, fake_ke
 
     fresh_collector.flush()
 
-    # kernel stats should show 1 hit & 1 miss
+    # kernel stats should show 1 hit
     assert fake_kernel.runtime_hits == 1
-    assert fake_kernel.runtime_misses == 1


### PR DESCRIPTION
When a cache miss occurs, it just means that the specific entry didn’t exist. Therefore, counting cache misses is meaningless.