### PR TITLE
chore: mcv client api return generic gpu fleet info

### DIFF
--- a/mcv/cmd/main.go
+++ b/mcv/cmd/main.go
@@ -45,7 +45,7 @@ func main() {
 
 func buildRootCommand() *cobra.Command {
 	var imageName, cacheDirName, logLevel string
-	var createFlag, extractFlag, baremetalFlag, noGPUFlag, hwInfoFlag, checkCompatFlag bool
+	var createFlag, extractFlag, baremetalFlag, noGPUFlag, hwInfoFlag, checkCompatFlag, gpuInfoFlag bool
 
 	cmd := &cobra.Command{
 		Use:   "mcv",
@@ -57,7 +57,7 @@ func buildRootCommand() *cobra.Command {
 			}
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			handleRunCommand(imageName, cacheDirName, logLevel, createFlag, extractFlag, baremetalFlag, noGPUFlag, hwInfoFlag, checkCompatFlag)
+			handleRunCommand(imageName, cacheDirName, logLevel, createFlag, extractFlag, baremetalFlag, noGPUFlag, hwInfoFlag, checkCompatFlag, gpuInfoFlag)
 		},
 	}
 
@@ -69,14 +69,19 @@ func buildRootCommand() *cobra.Command {
 	cmd.Flags().BoolVarP(&baremetalFlag, "baremetal", "b", false, "Run baremetal preflight checks")
 	cmd.Flags().BoolVar(&noGPUFlag, "no-gpu", false, "Disable GPU logic for testing")
 	cmd.Flags().BoolVar(&hwInfoFlag, "hw-info", false, "Display system hardware info")
+	cmd.Flags().BoolVar(&gpuInfoFlag, "gpu-info", false, "Display GPU info")
 	cmd.Flags().BoolVar(&checkCompatFlag, "check-compat", false, "Check system GPU compatibility with a given image")
 
 	return cmd
 }
 
-func handleRunCommand(imageName, cacheDirName, logLevel string, createFlag, extractFlag, baremetalFlag, noGPUFlag, hwInfoFlag, checkCompatFlag bool) {
+func handleRunCommand(imageName, cacheDirName, logLevel string, createFlag, extractFlag, baremetalFlag, noGPUFlag, hwInfoFlag, checkCompatFlag, gpuInfoFlag bool) {
 	if hwInfoFlag {
 		handleHWInfo()
+	}
+
+	if gpuInfoFlag {
+		handleGPUInfo()
 	}
 
 	if checkCompatFlag {
@@ -110,6 +115,16 @@ func handleHWInfo() {
 		os.Exit(exitLogError)
 	}
 	client.PrintXPUInfo(xpu)
+	os.Exit(exitNormal)
+}
+
+func handleGPUInfo() {
+	summary, err := client.GetSystemGPUInfo()
+	if err != nil {
+		logging.Errorf("Error getting system hardware: %v", err)
+		os.Exit(exitLogError)
+	}
+	client.PrintGPUSummary(summary)
 	os.Exit(exitNormal)
 }
 

--- a/mcv/pkg/accelerator/devices/amd.go
+++ b/mcv/pkg/accelerator/devices/amd.go
@@ -272,6 +272,7 @@ func (r *gpuAMD) Init() error {
 				WarpSize:          64,
 				MemoryTotalMB:     memTotal,
 				Backend:           "hip",
+				ID:                gpuID,
 			},
 			Summary: DeviceSummary{
 				ID:            strconv.Itoa(gpuID),

--- a/mcv/pkg/accelerator/devices/amd.go
+++ b/mcv/pkg/accelerator/devices/amd.go
@@ -261,7 +261,7 @@ func (r *gpuAMD) Init() error {
 	for gpuID, info := range gpuInfoList.GPUInfo {
 		memTotal := calculateMemoryMB(info.VRAM.Size.Value, info.VRAM.Size.Unit)
 		name := "card" + strconv.Itoa(gpuID)
-		prodName, _ := GetProductName(gpuID) //TODO error checking in the future
+		prodName, _ := GetProductName(gpuID) // TODO error checking in the future
 		r.devices[gpuID] = GPUDevice{
 			ID: gpuID,
 			TritonInfo: TritonGPUInfo{
@@ -356,7 +356,8 @@ func getAMDListInfo(ctx context.Context) (map[int]*AMDListInfo, error) {
 
 func (r *gpuAMD) GetAllGPUInfo() ([]TritonGPUInfo, error) {
 	var allTritonInfo []TritonGPUInfo
-	for gpuID, dev := range r.devices {
+	for gpuID := range r.devices {
+		dev := r.devices[gpuID]
 		allTritonInfo = append(allTritonInfo, dev.TritonInfo)
 		logging.Debugf("GPU %d: %+v", gpuID, dev.TritonInfo)
 	}
@@ -373,7 +374,8 @@ func (r *gpuAMD) GetGPUInfo(gpuID int) (TritonGPUInfo, error) {
 
 func (r *gpuAMD) GetAllSummaries() ([]DeviceSummary, error) {
 	var allAccInfo []DeviceSummary
-	for gpuID, dev := range r.devices {
+	for gpuID := range r.devices {
+		dev := r.devices[gpuID]
 		allAccInfo = append(allAccInfo, dev.Summary)
 		logging.Debugf("GPU %d: %+v", gpuID, dev.TritonInfo)
 	}

--- a/mcv/pkg/accelerator/devices/device.go
+++ b/mcv/pkg/accelerator/devices/device.go
@@ -64,10 +64,10 @@ type Device interface {
 	// Shutdown stops the metric device
 	Shutdown() bool
 	// GetGPUInfo returns the triton info for a specific GPU
-	GetGPUInfo(gpuID int) (TritonGPUInfo, error) //TODO rename
+	GetGPUInfo(gpuID int) (TritonGPUInfo, error) // TODO rename
 	GetSummary(gpuID int) (DeviceSummary, error)
 	// GetAllGPUInfo returns the triton info for a all GPUs on the host
-	GetAllGPUInfo() ([]TritonGPUInfo, error) //TODO rename
+	GetAllGPUInfo() ([]TritonGPUInfo, error) // TODO rename
 	GetAllSummaries() ([]DeviceSummary, error)
 }
 

--- a/mcv/pkg/accelerator/devices/device.go
+++ b/mcv/pkg/accelerator/devices/device.go
@@ -17,6 +17,8 @@ package devices
 
 import (
 	"errors"
+	"sort"
+	"strconv"
 	"sync"
 
 	"github.com/redhat-et/TKDK/mcv/pkg/config"
@@ -62,9 +64,27 @@ type Device interface {
 	// Shutdown stops the metric device
 	Shutdown() bool
 	// GetGPUInfo returns the triton info for a specific GPU
-	GetGPUInfo(gpuID int) (TritonGPUInfo, error)
+	GetGPUInfo(gpuID int) (TritonGPUInfo, error) //TODO rename
+	GetSummary(gpuID int) (DeviceSummary, error)
 	// GetAllGPUInfo returns the triton info for a all GPUs on the host
-	GetAllGPUInfo() ([]TritonGPUInfo, error)
+	GetAllGPUInfo() ([]TritonGPUInfo, error) //TODO rename
+	GetAllSummaries() ([]DeviceSummary, error)
+}
+
+type DeviceSummary struct {
+	ID            string
+	DriverVersion string
+	ProductName   string
+}
+
+type GPUFleetSummary struct {
+	GPUs []GPUGroup `json:"gpus" yaml:"gpus"`
+}
+
+type GPUGroup struct {
+	GPUType       string `json:"gpuType" yaml:"gpuType"`
+	DriverVersion string `json:"driverVersion" yaml:"driverVersion"`
+	IDs           []int  `json:"ids" yaml:"ids"`
 }
 
 // Registry gets the default device Registry instance
@@ -169,4 +189,55 @@ func Startup(a string) Device {
 	// The device type is unsupported
 	logging.Errorf("unsupported Device")
 	return nil
+}
+
+// SummarizeGPUs starts the currently-registered GPU device, collects all
+// summaries, coalesces them into your desired output shape, and returns it.
+func SummarizeGPUs() (*GPUFleetSummary, error) {
+	dev := Startup(config.GPU)
+	if dev == nil {
+		return nil, errors.New("no GPU device available")
+	}
+	defer dev.Shutdown()
+
+	summaries, err := dev.GetAllSummaries()
+	if err != nil {
+		return nil, err
+	}
+
+	// Group by (ProductName, DriverVersion)
+	type key struct {
+		product string
+		driver  string
+	}
+	groups := map[key]*GPUGroup{}
+
+	for _, s := range summaries {
+		idInt, _ := strconv.Atoi(s.ID) // IDs are strings in DeviceSummary; best-effort parse
+
+		k := key{product: s.ProductName, driver: s.DriverVersion}
+		if _, ok := groups[k]; !ok {
+			groups[k] = &GPUGroup{
+				GPUType:       s.ProductName,
+				DriverVersion: s.DriverVersion,
+				IDs:           []int{},
+			}
+		}
+		groups[k].IDs = append(groups[k].IDs, idInt)
+	}
+
+	// Build deterministic, sorted output
+	out := &GPUFleetSummary{GPUs: make([]GPUGroup, 0, len(groups))}
+	for _, g := range groups {
+		sort.Ints(g.IDs)
+		out.GPUs = append(out.GPUs, *g)
+	}
+	sort.Slice(out.GPUs, func(i, j int) bool {
+		if out.GPUs[i].GPUType == out.GPUs[j].GPUType {
+			return out.GPUs[i].DriverVersion < out.GPUs[j].DriverVersion
+		}
+		return out.GPUs[i].GPUType < out.GPUs[j].GPUType
+	})
+
+	return out, nil
 }

--- a/mcv/pkg/accelerator/devices/mock.go
+++ b/mcv/pkg/accelerator/devices/mock.go
@@ -78,3 +78,11 @@ func (d *MockDevice) GetGPUInfo(gpuID int) (TritonGPUInfo, error) {
 func (d *MockDevice) GetAllGPUInfo() ([]TritonGPUInfo, error) {
 	return []TritonGPUInfo{}, nil
 }
+
+func (d *MockDevice) GetAllSummaries() ([]DeviceSummary, error) {
+	return []DeviceSummary{}, nil
+}
+
+func (d *MockDevice) GetSummary(gpuID int) (DeviceSummary, error) {
+	return DeviceSummary{}, nil
+}

--- a/mcv/pkg/accelerator/devices/nvml.go
+++ b/mcv/pkg/accelerator/devices/nvml.go
@@ -140,8 +140,8 @@ func (n *gpuNvml) Init() (err error) {
 		if err != nil {
 			return err
 		}
-		prodName, _ := GetProductName(gpuID)              //TODO error checking in the future
-		driverVersion, _ := nvml.SystemGetDriverVersion() //TODO error checking in the future
+		prodName, _ := GetProductName(gpuID)              // TODO error checking in the future
+		driverVersion, _ := nvml.SystemGetDriverVersion() // TODO error checking in the future
 		dev := GPUDevice{
 			ID:         gpuID,
 			TritonInfo: tritonInfo,
@@ -214,7 +214,8 @@ func (n *gpuNvml) GetGPUInfo(gpuID int) (TritonGPUInfo, error) {
 func (n *gpuNvml) GetAllGPUInfo() ([]TritonGPUInfo, error) {
 	var allTritonInfo []TritonGPUInfo
 
-	for gpuID, dev := range n.devices {
+	for gpuID := range n.devices {
+		dev := n.devices[gpuID]
 		allTritonInfo = append(allTritonInfo, dev.TritonInfo)
 		logging.Infof("GPU %d: %+v", gpuID, dev.TritonInfo)
 	}

--- a/mcv/pkg/accelerator/devices/nvml.go
+++ b/mcv/pkg/accelerator/devices/nvml.go
@@ -136,6 +136,7 @@ func (n *gpuNvml) Init() (err error) {
 		}
 
 		tritonInfo, err := getNVMLTritonGPUInfo(device)
+		tritonInfo.ID = gpuID
 		if err != nil {
 			return err
 		}

--- a/mcv/pkg/accelerator/devices/nvml.go
+++ b/mcv/pkg/accelerator/devices/nvml.go
@@ -139,10 +139,14 @@ func (n *gpuNvml) Init() (err error) {
 		if err != nil {
 			return err
 		}
-
+		prodName, _ := GetProductName(gpuID)              //TODO error checking in the future
+		driverVersion, _ := nvml.SystemGetDriverVersion() //TODO error checking in the future
 		dev := GPUDevice{
 			ID:         gpuID,
 			TritonInfo: tritonInfo,
+			Summary: DeviceSummary{ID: strconv.Itoa(gpuID),
+				ProductName:   prodName,
+				DriverVersion: driverVersion},
 		}
 
 		n.devices[gpuID] = dev
@@ -225,4 +229,14 @@ func nvmlErrorString(errno nvml.Return) string {
 		return "ERROR_LIBRARY_NOT_FOUND"
 	}
 	return fmt.Sprintf("Error %d", errno)
+}
+
+// GetAllSummaries implements Device.
+func (n *gpuNvml) GetAllSummaries() ([]DeviceSummary, error) {
+	panic("unimplemented")
+}
+
+// GetSummary implements Device.
+func (n *gpuNvml) GetSummary(gpuID int) (DeviceSummary, error) {
+	panic("unimplemented")
 }

--- a/mcv/pkg/accelerator/devices/rocm.go
+++ b/mcv/pkg/accelerator/devices/rocm.go
@@ -120,6 +120,7 @@ func (r *gpuROCm) Init() error {
 	for gpuID, info := range gpuInfoList.GPUInfo {
 		memTotal, _ := strconv.ParseUint(info.VRAMTotalMemory, 10, 64)
 		name := "card" + strconv.Itoa(gpuID)
+		prodName, _ := GetProductName(gpuID) //TODO error checking in the future
 		r.devices[gpuID] = GPUDevice{
 			ID: gpuID,
 			TritonInfo: TritonGPUInfo{
@@ -130,6 +131,11 @@ func (r *gpuROCm) Init() error {
 				WarpSize:          64,
 				MemoryTotalMB:     memTotal / (1024 * 1024),
 				Backend:           "hip",
+			},
+			Summary: DeviceSummary{
+				ID:            strconv.Itoa(gpuID),
+				ProductName:   prodName,
+				DriverVersion: gpuInfoList.DrvInfo.System.DriverVersion,
 			},
 		}
 	}
@@ -231,4 +237,21 @@ func (r *gpuROCm) GetGPUInfo(gpuID int) (TritonGPUInfo, error) {
 		return TritonGPUInfo{}, fmt.Errorf("GPU device %d not found", gpuID)
 	}
 	return dev.TritonInfo, nil
+}
+
+func (r *gpuROCm) GetAllSummaries() ([]DeviceSummary, error) {
+	var allAccInfo []DeviceSummary
+	for gpuID, dev := range r.devices {
+		allAccInfo = append(allAccInfo, dev.Summary)
+		logging.Debugf("GPU %d: %+v", gpuID, dev.TritonInfo)
+	}
+	return allAccInfo, nil
+}
+
+func (r *gpuROCm) GetSummary(gpuID int) (DeviceSummary, error) {
+	dev, exists := r.devices[gpuID]
+	if !exists {
+		return DeviceSummary{}, fmt.Errorf("GPU device %d not found", gpuID)
+	}
+	return dev.Summary, nil
 }

--- a/mcv/pkg/accelerator/devices/rocm.go
+++ b/mcv/pkg/accelerator/devices/rocm.go
@@ -131,6 +131,7 @@ func (r *gpuROCm) Init() error {
 				WarpSize:          64,
 				MemoryTotalMB:     memTotal / (1024 * 1024),
 				Backend:           "hip",
+				ID:                gpuID,
 			},
 			Summary: DeviceSummary{
 				ID:            strconv.Itoa(gpuID),

--- a/mcv/pkg/accelerator/devices/rocm.go
+++ b/mcv/pkg/accelerator/devices/rocm.go
@@ -120,7 +120,7 @@ func (r *gpuROCm) Init() error {
 	for gpuID, info := range gpuInfoList.GPUInfo {
 		memTotal, _ := strconv.ParseUint(info.VRAMTotalMemory, 10, 64)
 		name := "card" + strconv.Itoa(gpuID)
-		prodName, _ := GetProductName(gpuID) //TODO error checking in the future
+		prodName, _ := GetProductName(gpuID) // TODO error checking in the future
 		r.devices[gpuID] = GPUDevice{
 			ID: gpuID,
 			TritonInfo: TritonGPUInfo{
@@ -224,7 +224,8 @@ func getROCmSystemInfo(ctx context.Context) (*ROCMSystemInfo, error) {
 // GetAllGPUInfo returns a list of GPU info for all devices
 func (r *gpuROCm) GetAllGPUInfo() ([]TritonGPUInfo, error) {
 	var allTritonInfo []TritonGPUInfo
-	for gpuID, dev := range r.devices {
+	for gpuID := range r.devices {
+		dev := r.devices[gpuID]
 		allTritonInfo = append(allTritonInfo, dev.TritonInfo)
 		logging.Debugf("GPU %d: %+v", gpuID, dev.TritonInfo)
 	}
@@ -242,7 +243,8 @@ func (r *gpuROCm) GetGPUInfo(gpuID int) (TritonGPUInfo, error) {
 
 func (r *gpuROCm) GetAllSummaries() ([]DeviceSummary, error) {
 	var allAccInfo []DeviceSummary
-	for gpuID, dev := range r.devices {
+	for gpuID := range r.devices {
+		dev := r.devices[gpuID]
 		allAccInfo = append(allAccInfo, dev.Summary)
 		logging.Debugf("GPU %d: %+v", gpuID, dev.TritonInfo)
 	}

--- a/mcv/pkg/accelerator/devices/types.go
+++ b/mcv/pkg/accelerator/devices/types.go
@@ -52,6 +52,8 @@ type TritonGPUInfo struct {
 	PTXVersion int `json:"ptx_version"`
 
 	Backend string `json:"backend"`
+
+	ID int
 }
 
 type GPUDevice struct {

--- a/mcv/pkg/accelerator/devices/types.go
+++ b/mcv/pkg/accelerator/devices/types.go
@@ -57,4 +57,5 @@ type TritonGPUInfo struct {
 type GPUDevice struct {
 	ID         int
 	TritonInfo TritonGPUInfo
+	Summary    DeviceSummary
 }

--- a/mcv/pkg/accelerator/devices/utils.go
+++ b/mcv/pkg/accelerator/devices/utils.go
@@ -1,0 +1,44 @@
+package devices
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/jaypipes/ghw"
+	logging "github.com/sirupsen/logrus"
+)
+
+func GetSystemHW() (cpuInfo *ghw.CPUInfo, accInfo *ghw.AcceleratorInfo, err error) {
+	cpuInfo, errCPU := ghw.CPU()
+	if errCPU != nil {
+		logging.Error("failed to get CPU info:", errCPU)
+	} else {
+		logging.Debug(cpuInfo)
+	}
+
+	accInfo, errAcc := ghw.Accelerator()
+	if errAcc != nil {
+		logging.Error("failed to get accelerator info:", errAcc)
+	} else {
+		for _, device := range accInfo.Devices {
+			logging.Debug(device)
+		}
+	}
+
+	err = errors.Join(errCPU, errAcc)
+	return
+}
+
+func GetProductName(id int) (name string, err error) {
+	xpus, errAcc := ghw.Accelerator()
+	if errAcc != nil {
+		logging.Error("failed to get accelerator info:", errAcc)
+	} else {
+		for i, device := range xpus.Devices {
+			if i == id && device.PCIDevice != nil {
+				return device.PCIDevice.Product.Name, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("PCI device information unavailable")
+}

--- a/mcv/pkg/client/client.go
+++ b/mcv/pkg/client/client.go
@@ -82,11 +82,11 @@ func ExtractCache(opts Options) (matchedIDs, unmatchedIDs []int, err error) {
 		return nil, nil, fmt.Errorf("image name must be specified")
 	}
 
-	if _, err := config.Initialize(config.ConfDir); err != nil {
+	if _, err = config.Initialize(config.ConfDir); err != nil {
 		return nil, nil, fmt.Errorf("failed to initialize config: %w", err)
 	}
 
-	if err := logformat.ConfigureLogging(opts.LogLevel); err != nil {
+	if err = logformat.ConfigureLogging(opts.LogLevel); err != nil {
 		return nil, nil, fmt.Errorf("error configuring logging: %v", err)
 	}
 

--- a/mcv/pkg/fetcher/imgfetcher.go
+++ b/mcv/pkg/fetcher/imgfetcher.go
@@ -164,10 +164,6 @@ func (e *tritonCacheExtractor) ExtractCache(img v1.Image) error {
 		return fmt.Errorf("failed to fetch manifest: %w", err)
 	}
 
-	if config.IsSkipPrecheckEnabled() {
-		logging.Info("Skipping preflight GPU compatibility checks (--skip-precheck enabled)")
-	}
-
 	if config.IsGPUEnabled() && !config.IsSkipPrecheckEnabled() {
 		devInfo, err = preflightcheck.GetAllGPUInfo(e.acc)
 		if err != nil {


### PR DESCRIPTION
mcv client api to return a generic device summary.
The extract function and preflight check function also return simple GPU matched and unmatched data

```
 _output/bin/linux_amd64/mcv --gpu-info
INFO[2025-08-08 15:37:16] Hardware accelerator(s) detected (2). GPU support enabled. 
INFO[2025-08-08 15:37:16] Adding the device to the registry [gpu][AMD] 
INFO[2025-08-08 15:37:16] Using AMD to obtain GPU info                 
INFO[2025-08-08 15:37:16] Error registering rocm-smi: AMD already registered. Skipping ROCM 
INFO[2025-08-08 15:37:16] Initializing the Accelerator of type gpu     
INFO[2025-08-08 15:37:16] Starting up AMD                              
INFO[2025-08-08 15:37:17] Using AMD to obtain GPU info                 
INFO[2025-08-08 15:37:17] Startup gpu Accelerator successful           
INFO[2025-08-08 15:37:17] Starting up AMD                              
INFO[2025-08-08 15:37:19] Using AMD to obtain GPU info                 
GPU Fleet:
  - GPU Type: Aldebaran/MI200 [Instinct MI210]
    Driver Version: 6.12.10-100.fc40.x86_64
    IDs: [0 1]
```