### PR TITLE
chore: sync podman auth for cosign in MCV example images workflow

### DIFF
--- a/.github/workflows/mcv-build-example-images.yml
+++ b/.github/workflows/mcv-build-example-images.yml
@@ -134,7 +134,11 @@ jobs:
 
             echo "==> Final digest list:"
             cat "${tmpfile}"
-
+      - name: Sync podman auth for cosign
+        if: ${{ fromJSON(steps.set-push.outputs.push_flag) }}
+        run: |
+          mkdir -p ~/.docker
+          cp ~/.config/containers/auth.json ~/.docker/config.json
       - name: Sign the images with GitHub OIDC Token
         if: ${{ fromJSON(steps.set-push.outputs.push_flag) }}
         env:


### PR DESCRIPTION
Add authentication sync step to copy podman's auth.json to Docker config location before signing images. Cosign looks for credentials in ~/.docker/config.json, while podman-login stores them in ~/.config/containers/auth.json. This ensures cosign can authenticate to the registry when pushing signature artifacts.