### PR TITLE
fix: add Docker login for cosign authentication

### DIFF
--- a/.github/workflows/mcv-build-example-images.yml
+++ b/.github/workflows/mcv-build-example-images.yml
@@ -61,10 +61,6 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.GH_USERNAME }}
           password: ${{ secrets.GH_TOKEN }}
-      - name: Make Podman credentials visible to Cosign
-        if: ${{ fromJSON(steps.set-push.outputs.push_flag) }}
-        run: echo "DOCKER_CONFIG=$HOME/.config/containers" >> $GITHUB_ENV
-
       - name: Pull MCV builder image
         run: podman pull quay.io/gkm/mcv:latest
 
@@ -137,6 +133,15 @@ jobs:
 
             echo "==> Final digest list:"
             cat "${tmpfile}"
+
+      # Needed for Cosign
+      - name: Login to quay.io (Docker)
+        uses: docker/login-action@v3
+        if: ${{ fromJSON(steps.set-push.outputs.push_flag) }}
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
       - name: Sign the images with GitHub OIDC Token
         if: ${{ fromJSON(steps.set-push.outputs.push_flag) }}
         env:


### PR DESCRIPTION
Add separate Docker login step for cosign to authenticate with Quay.io. Cosign requires Docker-style credentials to push signature artifacts, which are separate from the podman login used for pushing images.

Remove the DOCKER_CONFIG environment variable approach as it was not sufficient - cosign needs proper Docker credentials via docker/login-action.