### PR TITLE
refactor:mcv examples align signing step with cosign reference example

### DIFF
--- a/.github/workflows/mcv-build-example-images.yml
+++ b/.github/workflows/mcv-build-example-images.yml
@@ -168,12 +168,9 @@ jobs:
       - name: Sign the images with GitHub OIDC Token
         env:
           DIGESTS: ${{ needs.build.outputs.digests }}
-        shell: bash
         run: |
-          set -euo pipefail
-          IFS=',' read -ra digest_array <<< "$DIGESTS"
-
-          for image_digest in "${digest_array[@]}"; do
-            echo "==> Signing ${image_digest}"
-            cosign sign --yes "${image_digest}"
+          images=""
+          for digest in ${DIGESTS//,/ }; do
+            images+="${digest} "
           done
+          cosign sign --yes ${images}


### PR DESCRIPTION
Update the signing step to match the pattern from the official cosign GitHub Actions example, signing all images in a single cosign command instead of looping through them individually.

This matches the approach used in sigstore/cosign's official examples and may improve signature artifact handling.

Reference: https://github.com/sigstore/cosign/blob/main/.github/workflows/kind-verify-attestation.yaml