### PR TITLE
fix: mcv exmaples add explicit permissions to sign job for OIDC token

### DIFF
--- a/.github/workflows/mcv-build-example-images.yml
+++ b/.github/workflows/mcv-build-example-images.yml
@@ -152,6 +152,10 @@ jobs:
     name: Sign example cache images
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: read
+      packages: write
+      id-token: write # needed for signing the images with GitHub OIDC Token
     if: github.event_name == 'push' && github.repository_owner == 'redhat-et'
 
     steps:


### PR DESCRIPTION
Add explicit permissions block to the sign job to ensure it has the required id-token: write permission for GitHub OIDC token-based signing.