### PR TITLE
fix: use legacy signature storage mode for Quay compatibility

### DIFF
--- a/.github/workflows/mcv-build-example-images.yml
+++ b/.github/workflows/mcv-build-example-images.yml
@@ -184,4 +184,4 @@ jobs:
           for digest in ${DIGESTS//,/ }; do
             images+="${digest} "
           done
-          cosign sign --yes -d ${images}
+          cosign sign --yes -d --registry-referrers-mode=legacy ${images}


### PR DESCRIPTION
Add --registry-referrers-mode=legacy flag to cosign signing command to store signatures using traditional .sig tag naming convention instead of OCI Referrers API.

This makes signatures visible as separate tags (sha256-{digest}.sig) in Quay's repository UI and may improve compatibility with Quay's signature verification features. With legacy mode, signatures are stored as: quay.io/gkm/cache-examples:sha256-{digest}.sig Instead of using the OCI Referrers API which may not be fully supported or visible in Quay's UI.