### PR TITLE
fix: mcv sign images by tag instead of digest for legacy mode

### DIFF
--- a/.github/workflows/mcv-build-example-images.yml
+++ b/.github/workflows/mcv-build-example-images.yml
@@ -178,10 +178,14 @@ jobs:
 
       - name: Sign the images with GitHub OIDC Token
         env:
-          DIGESTS: ${{ needs.build.outputs.digests }}
+          TAGS: ${{ needs.build.outputs.tags }}
+          REGISTRY: ${{ env.REGISTRY }}
+          ORG: ${{ env.ORG }}
+          REPO: ${{ env.REPO }}
         run: |
+          repo="${REGISTRY}/${ORG}/${REPO}"
           images=""
-          for digest in ${DIGESTS//,/ }; do
-            images+="${digest} "
+          for tag in ${TAGS//,/ }; do
+            images+="${repo}:${tag} "
           done
           cosign sign --yes -d --registry-referrers-mode=legacy ${images}


### PR DESCRIPTION
Change cosign signing to use image tags instead of digests when using legacy signature storage mode. This ensures signatures are properly associated with the tagged images and creates .sig tags in the format: sha256-{digest}.sig