### PR TITLE
fix: mcv downgrade cosign to v2.6.1 for legacy signature compatibility

### DIFF
--- a/.github/workflows/mcv-build-example-images.yml
+++ b/.github/workflows/mcv-build-example-images.yml
@@ -159,13 +159,10 @@ jobs:
     if: github.event_name == 'push' && github.repository_owner == 'redhat-et'
 
     steps:
-      - name: Install go
-        uses: actions/setup-go@v6.0.0
-        with:
-          go-version: "1.24"
-          check-latest: true
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.0.0
+        uses: sigstore/cosign-installer@v3.10.1
+        with:
+          cosign-release: v2.6.1
       - name: Check install!
         run: cosign version
 
@@ -188,4 +185,4 @@ jobs:
           for tag in ${TAGS//,/ }; do
             images+="${repo}:${tag} "
           done
-          cosign sign --yes -d --registry-referrers-mode=legacy ${images}
+          cosign sign --yes -d ${images}


### PR DESCRIPTION
Downgrade cosign from v3.x to v2.6.1 to improve compatibility with legacy signature storage mode and Quay.io signature display.