### PR TITLE
fix: upgrade Go version to 1.25.0 for mcv

### DIFF
--- a/.github/workflows/mcv-build.yml
+++ b/.github/workflows/mcv-build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.24
+          go-version: 1.25.0
 
       - name: Install required packages
         run: |
@@ -31,8 +31,7 @@ jobs:
 
       - name: Install golangci-lint
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
-            | sh -s -- -b /usr/local/bin v2.0.2
+          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 
       - name: Prepare vendored dependencies
         working-directory: mcv
@@ -43,7 +42,7 @@ jobs:
       - name: Run golangci-lint
         working-directory: mcv
         run: |
-          GOFLAGS=-mod=vendor golangci-lint run --timeout=5m --modules-download-mode=vendor ./...
+          golangci-lint run --timeout=5m --modules-download-mode=vendor ./...
 
       - name: Build with Makefile
         run: make mcv

--- a/mcv/.golangci.yml
+++ b/mcv/.golangci.yml
@@ -61,32 +61,3 @@ linters:
 
     misspell:
       locale: US
-
-exclusions:
-  generated: lax
-  presets:
-    - comments
-    - common-false-positives
-    - legacy
-    - std-error-handling
-  paths:
-    - ^third_party/
-    - ^builtin/
-    - ^examples/
-    - ^vendor/
-
-formatters:
-  enable:
-    - gofmt
-    - goimports
-  settings:
-    goimports:
-      local-prefixes:
-        - github.com/golangci/golangci-lint
-  exclusions:
-    generated: lax
-    paths:
-      - ^third_party/
-      - ^builtin/
-      - ^examples/
-      - ^vendor/

--- a/mcv/README.md
+++ b/mcv/README.md
@@ -20,7 +20,11 @@ A Model/GPU kernel cache container packaging utility inspired by
 
 ## Build Instructions
 
-Install dependencies:
+### Requirements
+
+- Go 1.25.0 or later
+
+### Install dependencies
 
 ```bash
 sudo dnf install gpgme-devel

--- a/mcv/go.mod
+++ b/mcv/go.mod
@@ -1,8 +1,6 @@
 module github.com/redhat-et/MCU/mcv
 
-go 1.24.2
-
-toolchain go1.24.10
+go 1.25.0
 
 require (
 	github.com/NVIDIA/go-nvml v0.13.0-1


### PR DESCRIPTION
Update Go version from 1.24.x to 1.25.0 to address CI failures caused by dependency requirements. One or more dependencies now require Go 1.25.0 as the minimum version.