### PR TITLE
mcm : Remove cluster_dims on kernel validation 

### DIFF
--- a/mcm/model_cache_manager/data/kernel_validator.py
+++ b/mcm/model_cache_manager/data/kernel_validator.py
@@ -91,7 +91,6 @@ def is_kernel_related(data: Dict[str, Any]) -> bool:
         "num_stages",
         "debug",
         "shared",
-        "cluster_dims",
     ]
 
     for field in kernel_specific_fields:


### PR DESCRIPTION
in order to be compatible with the new triton kernel metadata