### PR TITLE
MCM: fix auto-detection of vLLM binary cache

### DIFF
--- a/mcm/model_cache_manager/data/kernel_validator.py
+++ b/mcm/model_cache_manager/data/kernel_validator.py
@@ -16,7 +16,7 @@ from ..plugins.base import KernelBackendPlugin
 log = logging.getLogger(__name__)
 
 
-class KernelTarget(BaseModel):
+class KernelTarget(BaseModel):  # pylint: disable=too-few-public-methods
     """Validation model for the 'target' field of kernel metadata."""
 
     backend: str = ""
@@ -24,7 +24,7 @@ class KernelTarget(BaseModel):
     warp_size: int = 0
 
 
-class KernelMetadata(BaseModel):
+class KernelMetadata(BaseModel):  # pylint: disable=too-few-public-methods
     """
     Pydantic model for validating kernel metadata.
 

--- a/mcm/model_cache_manager/tests/utils/test_cache_mode_detection.py
+++ b/mcm/model_cache_manager/tests/utils/test_cache_mode_detection.py
@@ -244,6 +244,23 @@ class TestCacheModeDetection(unittest.TestCase):
         mode = detect_cache_mode(cache_dir)
         self.assertEqual(mode, MODE_TRITON)
 
+    def test_detect_vllm_binary_cache_structure(self):
+        """Test detection of new vLLM cache structure with binary artifacts."""
+        # Binary artifacts are files (not directories) named artifact_compile_range_*
+        vllm_dir = self.temp_dir / "vllm_binary"
+        torch_compile = vllm_dir / "torch_compile_cache"
+        hash_dir = torch_compile / "some_vllm_hash"
+        rank_dir = hash_dir / "rank_0_0"
+        backbone_dir = rank_dir / "backbone"
+        backbone_dir.mkdir(parents=True)
+
+        # Create a binary artifact file (not a directory)
+        binary_artifact = backbone_dir / "artifact_compile_range_0"
+        binary_artifact.write_bytes(b"\x00binary data")
+
+        mode = detect_cache_mode(vllm_dir)
+        self.assertEqual(mode, MODE_VLLM)
+
     def test_detect_mixed_legacy_and_triton_vllm_takes_precedence(self):
         """Test detection when both vllm-legacy and triton structures exist."""
         cache_dir = self.temp_dir / "mixed_cache"

--- a/mcm/model_cache_manager/utils/utils.py
+++ b/mcm/model_cache_manager/utils/utils.py
@@ -198,8 +198,12 @@ def iter_artifact_compile_range_dirs(backbone_dir: Path):
 
 
 def _has_artifact_compile_range_with_triton(backbone_dir: Path) -> bool:
-    """Check if backbone directory has artifact_compile_range subdirectories with triton."""
+    """Check if backbone directory has artifact_compile_range artifacts (unpacked or binary)."""
     for artifact_dir in iter_artifact_compile_range_dirs(backbone_dir):
+        # Binary artifact (file) — contains packed triton data
+        if artifact_dir.is_file():
+            return True
+        # Unpacked artifact (directory) — check for triton subdirectory
         triton_dir = artifact_dir / "triton"
         if triton_dir.exists():
             return True

--- a/mcm/pyproject.toml
+++ b/mcm/pyproject.toml
@@ -10,17 +10,20 @@ authors         = [{name = "Alessandro Sangiorgi", email = "asangior@redhat.com"
 requires-python = ">=3.9"
 
 dependencies = [
-  "triton",
   "rich>=13.7",
   "typer[all]",
   "structlog",
   "pydantic>=2",
   "pydantic-settings>=2",
   "sqlalchemy>=2.0.40",
+  "vllm==0.15.1",
 ]
 
 [project.scripts]
 mcm = "model_cache_manager.cli.main:run"
+
+[tool.pylint."messages_control"]
+disable = ["import-error"]
 
 [tool.setuptools]
 package-dir = {"" = "."}

--- a/mcm/requirements.txt
+++ b/mcm/requirements.txt
@@ -1,8 +1,8 @@
-typer>=0.9.0
+typer[all]
 rich>=13.7
 pydantic>=2.0.0
 pydantic-settings>=2.0.0
-structlog>=23.0.0
+structlog
 sqlalchemy>=2.0.40
 pytest>=7.0.0
-vllm
+vllm==0.15.1


### PR DESCRIPTION
  _has_artifact_compile_range_with_triton() only checked for a triton/
  subdirectory, which cannot exist when the artifact is a packed binary
  file. Recognize binary artifact_compile_range_* files as valid vLLM
  cache indicators so detect_cache_mode() returns 'vllm' instead of
  falling through to 'triton'.

  Also:
  - sync requirements.txt with pyproject.toml (typer[all], structlog)
  - silence pylint R0903 on Pydantic data models
  - disable pylint import-error for declared but not-installed deps