### PR TITLE
Add Helion cache mode support

### DIFF
--- a/mcm/model_cache_manager/cli/cli_helpers.py
+++ b/mcm/model_cache_manager/cli/cli_helpers.py
@@ -11,9 +11,9 @@ import typer
 import rich
 from ..utils.paths import get_cache_dir, get_db_path
 from ..utils.utils import detect_cache_mode
-from ..utils.mcm_constants import MODE_TRITON, MODE_VLLM
+from ..utils.mcm_constants import MODE_TRITON, MODE_VLLM, MODE_HELION
 
-VALID_MODES = (MODE_TRITON, MODE_VLLM)
+VALID_MODES = (MODE_TRITON, MODE_VLLM, MODE_HELION)
 
 
 def resolve_mode(explicit: Optional[str], cache_dir: Optional[Path]) -> str:

--- a/mcm/model_cache_manager/cli/cli_helpers.py
+++ b/mcm/model_cache_manager/cli/cli_helpers.py
@@ -11,9 +11,9 @@ import typer
 import rich
 from ..utils.paths import get_cache_dir, get_db_path
 from ..utils.utils import detect_cache_mode
-from ..utils.mcm_constants import MODE_TRITON, MODE_VLLM, MODE_HELION
+from ..utils.mcm_constants import MODE_TRITON, MODE_VLLM, MODE_VLLM_LEGACY, MODE_HELION
 
-VALID_MODES = (MODE_TRITON, MODE_VLLM, MODE_HELION)
+VALID_MODES = (MODE_TRITON, MODE_VLLM, MODE_VLLM_LEGACY, MODE_HELION)
 
 
 def resolve_mode(explicit: Optional[str], cache_dir: Optional[Path]) -> str:

--- a/mcm/model_cache_manager/cli/main.py
+++ b/mcm/model_cache_manager/cli/main.py
@@ -24,7 +24,7 @@ from ..services.prune import PruningService, PruneStats
 from ..services.warm import WarmupService
 from .cli_helpers import resolve_mode, ensure_db, service_ctx
 from .cli_options import get_common_search_options, CommonSearchOptions, WarmOptions
-from ..utils.mcm_constants import MODE_VLLM, MODE_TRITON
+from ..utils.mcm_constants import MODE_VLLM, MODE_TRITON, MODE_HELION
 
 
 log = logging.getLogger(__name__)
@@ -122,7 +122,7 @@ def _display_kernels_table(rows: List[Dict[str, Any]], mode: str = MODE_TRITON):
     )
     table.add_column("Hash", style="dim", width=15, overflow="fold")
     table.add_column("Name", style="cyan", min_width=20, overflow="fold")
-    if mode == MODE_VLLM:
+    if mode in (MODE_VLLM, MODE_HELION):
         table.add_column("Best", style="bold yellow", width=4)
     table.add_column("Hits", style="green", min_width=5, overflow="fold")
     table.add_column("Last Access", style="magenta", width=18)
@@ -145,6 +145,7 @@ def _display_kernels_table(rows: List[Dict[str, Any]], mode: str = MODE_TRITON):
         hash_display_strategies = {
             MODE_TRITON: lambda r: r.get("hash", "N/A")[:12] + "...",
             MODE_VLLM: lambda r: r.get("vllm_hash", "N/A"),
+            MODE_HELION: lambda r: r.get("triton_cache_key", "N/A")[:12] + "...",
         }
         hash_mode = hash_display_strategies.get(mode, lambda r: r.get("hash", "N/A"))(
             row_dict
@@ -153,8 +154,8 @@ def _display_kernels_table(rows: List[Dict[str, Any]], mode: str = MODE_TRITON):
         # Build row data based on mode
         row_data = [hash_mode, row_dict.get("name", "N/A")]
 
-        # Add BEST indicator for vLLM mode
-        if mode == MODE_VLLM:
+        # Add BEST indicator for vLLM and Helion modes
+        if mode in (MODE_VLLM, MODE_HELION):
             is_best = row_dict.get("is_best", False)
             row_data.append("Y" if is_best else "")
 

--- a/mcm/model_cache_manager/data/cache_repo.py
+++ b/mcm/model_cache_manager/data/cache_repo.py
@@ -12,7 +12,7 @@ import os
 import threading
 from typing import Iterable, Optional
 from ..utils.paths import get_cache_dir
-from ..utils.utils import iter_artifact_compile_range_dirs, _resolve_helion_triton_dir
+from ..utils.utils import iter_artifact_compile_range_dirs, resolve_helion_triton_dir
 from ..utils.mcm_constants import MODE_HELION
 from ..models.kernel import Kernel
 from ..plugins.discovery import discover_plugins
@@ -603,7 +603,7 @@ class HelionCacheRepository:  # pylint: disable=too-few-public-methods
             Tuples of (cache_dir, triton_cache_key, helion_hash,
                        best_config, is_best, kernel)
         """
-        triton_dir = _resolve_helion_triton_dir(self.root)
+        triton_dir = resolve_helion_triton_dir(self.root)
         if triton_dir is None:
             log.warning("No triton directory found in %s", self.root)
             return

--- a/mcm/model_cache_manager/data/cache_repo.py
+++ b/mcm/model_cache_manager/data/cache_repo.py
@@ -12,7 +12,8 @@ import os
 import threading
 from typing import Iterable, Optional
 from ..utils.paths import get_cache_dir
-from ..utils.utils import iter_artifact_compile_range_dirs
+from ..utils.utils import iter_artifact_compile_range_dirs, _resolve_helion_triton_dir
+from ..utils.mcm_constants import MODE_HELION
 from ..models.kernel import Kernel
 from ..plugins.discovery import discover_plugins
 from .kernel_validator import deserialize_kernel
@@ -555,3 +556,79 @@ class VllmCacheRepository:  # pylint: disable=too-few-public-methods
 
         # Fallback: torch_compile_cache (older caches without torch_aot_compile)
         yield from self._iter_torch_compile_kernels()
+
+
+HELION_KERNEL_PREFIX = "_helion_"
+
+
+class HelionCacheRepository:  # pylint: disable=too-few-public-methods
+    """Repository for accessing and managing Helion kernel cache files."""
+
+    def __init__(self, root: Path | None = None):
+        self.root = root or get_cache_dir(MODE_HELION)
+        if not self.root.exists():
+            raise FileNotFoundError(
+                f"Helion cache directory not found: {self.root}"
+            )
+
+    def _read_best_configs(self) -> dict[str, tuple[str, str]]:
+        """Read all ``*.best_config`` files and build a lookup.
+
+        Returns:
+            Mapping of ``backend_cache_key`` to
+            ``(helion_hash, raw_json_content)`` for each best_config file.
+        """
+        configs: dict[str, tuple[str, str]] = {}
+        for path in self.root.glob("*.best_config"):
+            helion_hash = path.stem
+            try:
+                raw = path.read_text(encoding="utf-8")
+                data = json.loads(raw)
+                backend_key = data.get("backend_cache_key")
+                if backend_key:
+                    configs[backend_key] = (helion_hash, raw)
+            except (json.JSONDecodeError, OSError) as exc:
+                log.warning("Could not read best_config %s: %s", path, exc)
+        return configs
+
+    def kernels(
+        self,
+    ) -> Iterable[tuple[str, str, Optional[str], Optional[str], bool, Kernel]]:
+        """Iterate through Helion kernels in the cache directory.
+
+        Only kernels whose name starts with ``_helion_`` are yielded;
+        regular triton kernels that may share the same directory are skipped.
+
+        Yields:
+            Tuples of (cache_dir, triton_cache_key, helion_hash,
+                       best_config, is_best, kernel)
+        """
+        triton_dir = _resolve_helion_triton_dir(self.root)
+        if triton_dir is None:
+            log.warning("No triton directory found in %s", self.root)
+            return
+
+        best_configs = self._read_best_configs()
+        plugins = _get_plugins()
+
+        for sub_dir in triton_dir.iterdir():
+            if not sub_dir.is_dir():
+                continue
+            for kernel in iter_triton_kernels(sub_dir, plugins):
+                if not kernel.name or not kernel.name.startswith(HELION_KERNEL_PREFIX):
+                    continue
+                match = best_configs.get(kernel.hash)
+                if match:
+                    helion_hash, best_config = match
+                    is_best = True
+                else:
+                    helion_hash, best_config = None, None
+                    is_best = False
+                yield (
+                    str(self.root),
+                    kernel.hash,
+                    helion_hash,
+                    best_config,
+                    is_best,
+                    kernel,
+                )

--- a/mcm/model_cache_manager/data/cache_repo.py
+++ b/mcm/model_cache_manager/data/cache_repo.py
@@ -584,8 +584,11 @@ class HelionCacheRepository:  # pylint: disable=too-few-public-methods
             try:
                 raw = path.read_text(encoding="utf-8")
                 data = json.loads(raw)
+                if not isinstance(data, dict):
+                    log.warning("Invalid best_config payload in %s", path)
+                    continue
                 backend_key = data.get("backend_cache_key")
-                if backend_key:
+                if isinstance(backend_key, str) and backend_key:
                     if backend_key in configs:
                         log.warning(
                             "Duplicate backend_cache_key '%s' in %s; keeping first occurrence",

--- a/mcm/model_cache_manager/data/cache_repo.py
+++ b/mcm/model_cache_manager/data/cache_repo.py
@@ -579,13 +579,20 @@ class HelionCacheRepository:  # pylint: disable=too-few-public-methods
             ``(helion_hash, raw_json_content)`` for each best_config file.
         """
         configs: dict[str, tuple[str, str]] = {}
-        for path in self.root.glob("*.best_config"):
+        for path in sorted(self.root.glob("*.best_config")):
             helion_hash = path.stem
             try:
                 raw = path.read_text(encoding="utf-8")
                 data = json.loads(raw)
                 backend_key = data.get("backend_cache_key")
                 if backend_key:
+                    if backend_key in configs:
+                        log.warning(
+                            "Duplicate backend_cache_key '%s' in %s; keeping first occurrence",
+                            backend_key,
+                            path,
+                        )
+                        continue
                     configs[backend_key] = (helion_hash, raw)
             except (json.JSONDecodeError, OSError) as exc:
                 log.warning("Could not read best_config %s: %s", path, exc)

--- a/mcm/model_cache_manager/data/database.py
+++ b/mcm/model_cache_manager/data/database.py
@@ -910,7 +910,8 @@ class HelionDatabase:
     def find_duplicates(self) -> List[List[Dict[str, Any]]]:
         """Finds groups of duplicate Helion kernels."""
         return database_utils.find_duplicates_generic(
-            self.SessionLocal, HelionKernelOrm, "triton_cache_key"
+            self.SessionLocal, HelionKernelOrm, "triton_cache_key",
+            ["cache_dir"],
         )
 
     def estimate_space(self, hashes: Iterable[str], f_ext: Set[str] | None) -> int:

--- a/mcm/model_cache_manager/data/database.py
+++ b/mcm/model_cache_manager/data/database.py
@@ -27,7 +27,6 @@ from .db_models import (
 
 from ..models.criteria import SearchCriteria
 from ..models.kernel import Kernel, VllmKernelMetadata
-from ..utils.mcm_constants import IR_EXTS
 from ..utils.utils import build_common_search_filters
 from . import database_utils
 from .database_utils import create_file_orm_dict
@@ -297,7 +296,7 @@ class Database:
 
             if f_ext:
                 q = q.filter(
-                    or_(*[KernelFileOrm.rel_path.like(f"%{ext}") for ext in IR_EXTS])
+                    or_(*[KernelFileOrm.rel_path.like(f"%{ext}") for ext in f_ext])
                 )
 
             size = q.scalar() or 0
@@ -335,7 +334,7 @@ class VllmDatabase:
             if f_ext:
                 q = q.filter(
                     or_(
-                        *[VllmKernelFileOrm.rel_path.like(f"%{ext}") for ext in IR_EXTS]
+                        *[VllmKernelFileOrm.rel_path.like(f"%{ext}") for ext in f_ext]
                     )
                 )
 
@@ -714,9 +713,6 @@ class VllmDatabase:
             log.info("vLLM Database engine connection pool disposed.")
 
 
-HELION_BATCH_ITEM_LENGTH = 5  # (kernel, cache_dir, helion_hash, best_config, is_best)
-
-
 class HelionDatabase:
     """Manages database interactions for Helion kernel metadata."""
 
@@ -928,7 +924,7 @@ class HelionDatabase:
                 q = q.filter(
                     or_(
                         *[HelionKernelFileOrm.rel_path.like(f"%{ext}")
-                          for ext in IR_EXTS]
+                          for ext in f_ext]
                     )
                 )
             size = q.scalar() or 0

--- a/mcm/model_cache_manager/data/database.py
+++ b/mcm/model_cache_manager/data/database.py
@@ -20,6 +20,8 @@ from .db_models import (
     KernelFileOrm,
     VllmKernelOrm,
     VllmKernelFileOrm,
+    HelionKernelOrm,
+    HelionKernelFileOrm,
     SqlaSession,
 )
 
@@ -710,3 +712,230 @@ class VllmDatabase:
         if self.engine:
             self.engine.dispose()
             log.info("vLLM Database engine connection pool disposed.")
+
+
+HELION_BATCH_ITEM_LENGTH = 5  # (kernel, cache_dir, helion_hash, best_config, is_best)
+
+
+class HelionDatabase:
+    """Manages database interactions for Helion kernel metadata."""
+
+    def __init__(self) -> None:
+        """Initializes DB engine, session factory, and ensures schema exists."""
+        self.engine, self.SessionLocal = create_engine_and_session(  # pylint: disable=invalid-name
+            "helion"
+        )
+        self._ensure_schema()
+        log.info("Helion Database service interface initialized successfully.")
+
+    def _ensure_schema(self) -> None:
+        """Ensures database schema (tables, indexes) exists."""
+        database_utils.ensure_schema(self.engine)
+
+    def get_session(self) -> SqlaSession:
+        """Returns a new database session."""
+        return self.SessionLocal()
+
+    def insert_kernel(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        self,
+        k_data: Kernel,
+        cache_dir: str,
+        helion_hash: str | None,
+        best_config: str | None,
+        is_best: bool,
+    ) -> None:
+        """Upserts a Helion kernel and its associated files into the database."""
+        session = self.get_session()
+        try:
+            HelionKernelOrm.upsert_from_dto(
+                session, k_data, cache_dir, helion_hash, best_config, is_best
+            )
+            session.commit()
+            log.info(
+                "Helion kernel %s with cache_dir %s upserted into DB.",
+                k_data.hash,
+                cache_dir,
+            )
+        except exc.IntegrityError as e:
+            session.rollback()
+            log.error(
+                "Failed to upsert Helion kernel %s: %s",
+                k_data.hash, e, exc_info=True,
+            )
+            raise
+        except exc.OperationalError as e:
+            session.rollback()
+            log.error(
+                "Failed to upsert Helion kernel %s: %s",
+                k_data.hash, e, exc_info=True,
+            )
+            raise
+        except Exception:
+            session.rollback()
+            log.error(
+                "DB Error: Failed to upsert Helion kernel %s.",
+                k_data.hash, exc_info=True,
+            )
+            raise
+        finally:
+            session.close()
+
+    def _upsert_helion_kernel(
+        self, session: SqlaSession, kernel_info: tuple
+    ) -> None:
+        """Upsert a single Helion kernel."""
+        k_data, cache_dir, helion_hash, best_config, is_best = kernel_info
+        kernel_values = HelionKernelOrm.get_helion_kernel_values(
+            k_data, cache_dir, helion_hash, best_config, is_best
+        )
+
+        stmt = sqlite_insert(HelionKernelOrm).values(kernel_values)
+        preserved_fields = {"runtime_hits", "last_access_time"}
+        update_dict = {
+            col.name: getattr(stmt.excluded, col.name)
+            for col in HelionKernelOrm.__table__.columns
+            if col.name not in ("triton_cache_key", "cache_dir")
+            and col.name not in preserved_fields
+        }
+        session.execute(
+            stmt.on_conflict_do_update(
+                index_elements=["triton_cache_key", "cache_dir"],
+                set_=update_dict,
+            )
+        )
+
+    def bulk_insert_kernels(
+        self, kernels_data: List[Tuple], batch_size: int = 1000
+    ) -> int:
+        """Bulk insert multiple Helion kernels efficiently."""
+        if not kernels_data:
+            log.info("No Helion kernels to insert")
+            return 0
+
+        session = self.get_session()
+        inserted_count = 0
+
+        try:
+            for i in range(0, len(kernels_data), batch_size):
+                batch = kernels_data[i : i + batch_size]
+
+                kernel_ids_to_clear = []
+                file_values_list = []
+                for item in batch:
+                    k_data, cache_dir = item[0], item[1]
+                    kernel_ids_to_clear.append((k_data.hash, str(cache_dir)))
+                    for f_dto in k_data.files:
+                        file_values_list.append(
+                            {
+                                "triton_cache_key": k_data.hash,
+                                "cache_dir": str(cache_dir),
+                                "type": f_dto.file_type,
+                                "rel_path": f_dto.path.name,
+                                "size": f_dto.size,
+                            }
+                        )
+
+                if kernel_ids_to_clear:
+                    session.query(HelionKernelFileOrm).filter(
+                        tuple_(
+                            HelionKernelFileOrm.triton_cache_key,
+                            HelionKernelFileOrm.cache_dir,
+                        ).in_(kernel_ids_to_clear)
+                    ).delete(synchronize_session="evaluate")
+
+                for kernel_info in batch:
+                    self._upsert_helion_kernel(session, kernel_info)
+                    inserted_count += 1
+
+                if file_values_list:
+                    session.bulk_insert_mappings(
+                        HelionKernelFileOrm, file_values_list
+                    )
+
+                session.commit()
+                log.info(
+                    "Batch of %d Helion kernels committed (%d total so far)",
+                    len(batch),
+                    inserted_count,
+                )
+
+        except Exception as e:
+            session.rollback()
+            log.error("Helion bulk insert failed: %s", e, exc_info=True)
+            raise
+        finally:
+            session.close()
+        return inserted_count
+
+    def search(self, criteria: SearchCriteria) -> List[Dict[str, Any]]:
+        """Searches for Helion kernels matching criteria."""
+        session = self.get_session()
+        try:
+            query = session.query(HelionKernelOrm)
+            equality_filter_configs = [
+                ("cache_dir", HelionKernelOrm.cache_dir, str),
+                ("name", HelionKernelOrm.name, None),
+                ("backend", HelionKernelOrm.backend, None),
+                ("arch", HelionKernelOrm.arch, str),
+            ]
+
+            active_filters = build_common_search_filters(
+                criteria, HelionKernelOrm, equality_filter_configs
+            )
+
+            if active_filters:
+                query = query.filter(and_(*active_filters))
+            query = query.order_by(HelionKernelOrm.modified_time.desc())
+            results_orm = query.all()
+
+            results = []
+            for kernel_orm in results_orm:
+                kernel_dict = kernel_orm.to_dict()
+                is_best = kernel_orm.is_best or False
+
+                if criteria.only_best is True and not is_best:
+                    continue
+                if criteria.only_best is False and is_best:
+                    continue
+
+                kernel_dict[KERNEL_DICT_IS_BEST_KEY] = is_best
+                results.append(kernel_dict)
+
+            return results
+        except Exception:  # pylint: disable=broad-except
+            log.error(
+                "Helion DB Search: Failed for criteria %s.",
+                criteria, exc_info=True,
+            )
+            return []
+        finally:
+            session.close()
+
+    def find_duplicates(self) -> List[List[Dict[str, Any]]]:
+        """Finds groups of duplicate Helion kernels."""
+        return database_utils.find_duplicates_generic(
+            self.SessionLocal, HelionKernelOrm, "triton_cache_key"
+        )
+
+    def estimate_space(self, hashes: Iterable[str], f_ext: Set[str] | None) -> int:
+        """Sum the sizes of artefacts that would be deleted."""
+        size = 0
+        with self.get_session() as s:
+            q = s.query(func.sum(HelionKernelFileOrm.size)).filter(
+                HelionKernelFileOrm.triton_cache_key.in_(hashes)
+            )
+            if f_ext:
+                q = q.filter(
+                    or_(
+                        *[HelionKernelFileOrm.rel_path.like(f"%{ext}")
+                          for ext in IR_EXTS]
+                    )
+                )
+            size = q.scalar() or 0
+        return size
+
+    def close(self) -> None:
+        """Closes the database engine's connection pool."""
+        if self.engine:
+            self.engine.dispose()
+            log.info("Helion Database engine connection pool disposed.")

--- a/mcm/model_cache_manager/data/db_models.py
+++ b/mcm/model_cache_manager/data/db_models.py
@@ -180,10 +180,12 @@ class KernelOrm(Base, BaseKernelMixin):
         )
 
         stmt = sqlite_insert(cls).values(kernel_values)
+        preserved_fields = {"runtime_hits", "last_access_time"}
         update_dict = {
             col.name: getattr(stmt.excluded, col.name)
             for col in cls.__table__.columns
             if col.name not in ("hash", "cache_dir")
+            and col.name not in preserved_fields
         }
         stmt = stmt.on_conflict_do_update(
             index_elements=["hash", "cache_dir"], set_=update_dict
@@ -295,11 +297,13 @@ class VllmLegacyKernelOrm(Base, BaseKernelMixin):
         )
 
         stmt = sqlite_insert(cls).values(kernel_values)
+        preserved_fields = {"runtime_hits", "last_access_time"}
         update_dict = {
             col.name: getattr(stmt.excluded, col.name)
             for col in cls.__table__.columns
             if col.name
             not in ("cache_dir", "rank_x_y", "vllm_hash", "triton_cache_key")
+            and col.name not in preserved_fields
         }
         stmt = stmt.on_conflict_do_update(
             index_elements=[
@@ -442,6 +446,7 @@ class VllmKernelOrm(Base, BaseKernelMixin):
         )
 
         stmt = sqlite_insert(cls).values(kernel_values)
+        preserved_fields = {"runtime_hits", "last_access_time"}
         update_dict = {
             col.name: getattr(stmt.excluded, col.name)
             for col in cls.__table__.columns
@@ -453,6 +458,7 @@ class VllmKernelOrm(Base, BaseKernelMixin):
                 "triton_cache_key",
                 "artifact_compile_range",
             )
+            and col.name not in preserved_fields
         }
         stmt = stmt.on_conflict_do_update(
             index_elements=[
@@ -674,10 +680,12 @@ class HelionKernelOrm(Base, BaseKernelMixin):
         )
 
         stmt = sqlite_insert(cls).values(kernel_values)
+        preserved_fields = {"runtime_hits", "last_access_time"}
         update_dict = {
             col.name: getattr(stmt.excluded, col.name)
             for col in cls.__table__.columns
             if col.name not in ("triton_cache_key", "cache_dir")
+            and col.name not in preserved_fields
         }
         stmt = stmt.on_conflict_do_update(
             index_elements=["triton_cache_key", "cache_dir"],

--- a/mcm/model_cache_manager/data/db_models.py
+++ b/mcm/model_cache_manager/data/db_models.py
@@ -609,3 +609,131 @@ class VllmKernelFileOrm(Base):  # pylint: disable=too-few-public-methods
     kernel: Mapped["VllmKernelOrm"] = relationship(
         "VllmKernelOrm", back_populates="files"
     )
+
+
+class HelionKernelOrm(Base, BaseKernelMixin):
+    """SQLAlchemy ORM model for a Helion Triton kernel."""
+
+    __tablename__ = "helion_kernels"
+
+    triton_cache_key: Mapped[str] = mapped_column(String, primary_key=True, index=True)
+    cache_dir: Mapped[str] = mapped_column(String, primary_key=True, index=True)
+    helion_hash: Mapped[Optional[str]] = mapped_column(String)
+    best_config: Mapped[Optional[str]] = mapped_column(String)
+    is_best: Mapped[Optional[bool]] = mapped_column(Boolean)
+
+    files: Mapped[List["HelionKernelFileOrm"]] = relationship(
+        "HelionKernelFileOrm",
+        back_populates="kernel",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Converts the ORM object to a dictionary."""
+        d = {c.key: getattr(self, c.key) for c in self.__table__.columns}
+        if "kernel_metadata_json" in d:
+            d["metadata"] = d.pop("kernel_metadata_json")
+        return d
+
+    @staticmethod
+    def get_helion_kernel_values(
+        k_data: Kernel,
+        cache_dir: str,
+        helion_hash: Optional[str],
+        best_config: Optional[str],
+        is_best: bool,
+    ) -> Dict[str, Any]:
+        """Get Helion-specific kernel values."""
+        kernel_values = HelionKernelOrm.get_common_kernel_values(k_data)
+        kernel_values.update(
+            {
+                "triton_cache_key": k_data.hash,
+                "cache_dir": cache_dir,
+                "helion_hash": helion_hash,
+                "best_config": best_config,
+                "is_best": is_best,
+            }
+        )
+        return kernel_values
+
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
+    @classmethod
+    def upsert_from_dto(
+        cls,
+        session: SqlaSession,
+        k_data: Kernel,
+        cache_dir: str,
+        helion_hash: Optional[str],
+        best_config: Optional[str],
+        is_best: bool,
+    ) -> None:
+        """Creates or updates a Helion kernel record from a Kernel DTO."""
+        kernel_values = cls.get_helion_kernel_values(
+            k_data, cache_dir, helion_hash, best_config, is_best
+        )
+
+        stmt = sqlite_insert(cls).values(kernel_values)
+        update_dict = {
+            col.name: getattr(stmt.excluded, col.name)
+            for col in cls.__table__.columns
+            if col.name not in ("triton_cache_key", "cache_dir")
+        }
+        stmt = stmt.on_conflict_do_update(
+            index_elements=["triton_cache_key", "cache_dir"],
+            set_=update_dict,
+        )
+        session.execute(stmt)
+        log.debug(
+            "Upserted Helion kernel triton_cache_key %s cache_dir %s",
+            k_data.hash,
+            cache_dir,
+        )
+
+        session.query(HelionKernelFileOrm).filter(
+            HelionKernelFileOrm.triton_cache_key == k_data.hash,
+            HelionKernelFileOrm.cache_dir == cache_dir,
+        ).delete(synchronize_session="fetch")
+
+        for f_dto in k_data.files:
+            kernel_file_orm = HelionKernelFileOrm(
+                triton_cache_key=k_data.hash,
+                cache_dir=cache_dir,
+                type=f_dto.file_type,
+                rel_path=f_dto.path.name,
+                size=f_dto.size,
+            )
+            session.add(kernel_file_orm)
+        log.debug(
+            "Added %d files for Helion kernel %s",
+            len(k_data.files),
+            k_data.hash,
+        )
+
+
+class HelionKernelFileOrm(Base):  # pylint: disable=too-few-public-methods
+    """SQLAlchemy ORM model for a file associated with a Helion kernel."""
+
+    __tablename__ = "helion_files"
+
+    id: Mapped[int] = mapped_column(
+        Integer, primary_key=True, index=True, autoincrement=True
+    )
+    triton_cache_key: Mapped[str] = mapped_column(String)
+    cache_dir: Mapped[str] = mapped_column(String)
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["triton_cache_key", "cache_dir"],
+            ["helion_kernels.triton_cache_key", "helion_kernels.cache_dir"],
+            ondelete="CASCADE",
+        ),
+    )
+
+    type: Mapped[Optional[str]] = mapped_column(String)
+    rel_path: Mapped[Optional[str]] = mapped_column(String)
+    size: Mapped[Optional[int]] = mapped_column(Integer)
+
+    kernel: Mapped["HelionKernelOrm"] = relationship(
+        "HelionKernelOrm", back_populates="files"
+    )

--- a/mcm/model_cache_manager/services/prune.py
+++ b/mcm/model_cache_manager/services/prune.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from rich.prompt import Confirm
 from .base import BaseService
 from ..models.criteria import SearchCriteria
-from ..utils.mcm_constants import IR_EXTS, MODE_VLLM
+from ..utils.mcm_constants import IR_EXTS, MODE_VLLM, MODE_HELION
 from ..utils.utils import (
     KernelIdentifier,
     extract_identifiers_from_groups,
@@ -316,6 +316,16 @@ class PruningService(BaseService):  # pylint: disable=too-few-public-methods
 
             ir_rows = (
                 session.query(config.file_orm_model).filter(*filter_conditions).all()
+            )
+        elif self.mode == MODE_HELION:
+            ir_rows = (
+                session.query(config.file_orm_model)
+                .filter(
+                    config.file_orm_model.triton_cache_key == identifier.hash_key,
+                    config.file_orm_model.cache_dir == str(self.cache_dir),
+                    config.file_orm_model.rel_path.in_(ir_file_names),
+                )
+                .all()
             )
         else:
             ir_rows = (

--- a/mcm/model_cache_manager/strategies/helion_strategy.py
+++ b/mcm/model_cache_manager/strategies/helion_strategy.py
@@ -1,0 +1,62 @@
+"""
+Strategy implementation for Helion cache mode.
+"""
+
+from __future__ import annotations
+from pathlib import Path
+from typing import Dict, Any
+
+from .base import CacheModeStrategy, CacheConfig
+from ..data.database import HelionDatabase
+from ..data.cache_repo import HelionCacheRepository
+from ..data.db_models import HelionKernelOrm, HelionKernelFileOrm
+from ..utils.utils import (
+    KernelIdentifier,
+    create_kernel_identifier,
+    process_kernels_in_batches,
+)
+
+
+class HelionStrategy(CacheModeStrategy):
+    """Strategy for handling Helion cache mode operations."""
+
+    @property
+    def config(self) -> CacheConfig:
+        """Return Helion cache configuration."""
+        return CacheConfig(
+            orm_model=HelionKernelOrm,
+            file_orm_model=HelionKernelFileOrm,
+            hash_field="triton_cache_key",
+            primary_key_fields=["triton_cache_key", "cache_dir"],
+        )
+
+    def create_database(self):
+        """Create HelionDatabase instance."""
+        return HelionDatabase()
+
+    def create_repository(self, cache_dir: Path):
+        """Create HelionCacheRepository instance."""
+        return HelionCacheRepository(cache_dir)
+
+    def extract_identifiers_from_row(self, row: Dict[str, Any]) -> KernelIdentifier:
+        """Extract kernel identifier from Helion database row."""
+        return create_kernel_identifier(
+            mode="helion", hash=row["triton_cache_key"]
+        )
+
+    def reindex_kernels(self, repo, db, batch_size: int = 1000) -> int:
+        """Perform Helion-specific kernel reindexing using streaming bulk insert."""
+        kernels_iterator = (
+            (kernel, cache_dir, helion_hash, best_config, is_best)
+            for cache_dir, _triton_cache_key, helion_hash,
+            best_config, is_best, kernel in repo.kernels()
+        )
+        return process_kernels_in_batches(kernels_iterator, db, batch_size)
+
+    def insert_kernel_strategy(self, db, k_data, *args, **kwargs) -> None:
+        """Strategy-specific kernel insertion for Helion."""
+        cache_dir = args[0] if len(args) > 0 else kwargs.get("cache_dir")
+        helion_hash = args[1] if len(args) > 1 else kwargs.get("helion_hash")
+        best_config = args[2] if len(args) > 2 else kwargs.get("best_config")
+        is_best = args[3] if len(args) > 3 else kwargs.get("is_best", False)
+        db.insert_kernel(k_data, cache_dir, helion_hash, best_config, is_best)

--- a/mcm/model_cache_manager/tests/cli/test_helion_cli.py
+++ b/mcm/model_cache_manager/tests/cli/test_helion_cli.py
@@ -1,0 +1,135 @@
+"""
+Integration tests for CLI with Helion mode support.
+"""
+
+import unittest
+from unittest.mock import patch, MagicMock
+import tempfile
+import shutil
+from pathlib import Path
+from typer.testing import CliRunner
+
+from model_cache_manager.cli.main import app
+
+
+class TestHelionCLI(unittest.TestCase):
+    """Test suite for CLI Helion mode functionality."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.runner = CliRunner()
+        self.temp_dir = Path(tempfile.mkdtemp())
+        self.helion_cache_dir = self.temp_dir / "helion_cache"
+        self.helion_cache_dir.mkdir(parents=True)
+
+    def tearDown(self):
+        """Clean up after each test method."""
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    @patch("model_cache_manager.cli.main.IndexService")
+    def test_index_command_explicit_helion_mode(self, mock_index_service):
+        """Test index command with explicit helion mode."""
+        mock_svc = MagicMock()
+        mock_svc.reindex.return_value = (2, 0)
+        mock_svc.repo.root = self.helion_cache_dir
+        mock_svc.cache_dir = self.helion_cache_dir
+        mock_index_service.return_value = mock_svc
+
+        result = self.runner.invoke(app, [
+            "index",
+            "--mode", "helion",
+            "--cache-dir", str(self.helion_cache_dir),
+        ])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Starting indexing process", result.stdout)
+        mock_index_service.assert_called_once_with(
+            cache_dir=self.helion_cache_dir,
+            mode="helion",
+        )
+
+    @patch("model_cache_manager.cli.cli_helpers.detect_cache_mode")
+    @patch("model_cache_manager.cli.main.IndexService")
+    def test_index_command_auto_detection_helion(self, mock_index_service, mock_detect):
+        """Test index command with auto-detection detecting helion."""
+        mock_detect.return_value = "helion"
+        mock_svc = MagicMock()
+        mock_svc.reindex.return_value = (1, 0)
+        mock_svc.repo.root = self.helion_cache_dir
+        mock_svc.cache_dir = self.helion_cache_dir
+        mock_index_service.return_value = mock_svc
+
+        result = self.runner.invoke(app, [
+            "index",
+            "--cache-dir", str(self.helion_cache_dir),
+        ])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Auto-detected cache mode: helion", result.stdout)
+        mock_detect.assert_called_once_with(self.helion_cache_dir)
+        mock_index_service.assert_called_once_with(
+            cache_dir=self.helion_cache_dir,
+            mode="helion",
+        )
+
+    @patch("model_cache_manager.cli.main.ensure_db")
+    @patch("model_cache_manager.cli.main.SearchService")
+    def test_list_command_helion_mode(self, mock_search_service, mock_ensure_db):
+        """Test list command with helion mode."""
+        mock_ensure_db.return_value = None
+        mock_svc = MagicMock()
+        mock_svc.search.return_value = []
+        mock_svc.close.return_value = None
+        mock_search_service.return_value = mock_svc
+
+        result = self.runner.invoke(app, [
+            "list",
+            "--mode", "helion",
+        ])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_search_service.assert_called_once()
+        call_args = mock_search_service.call_args
+        self.assertEqual(call_args[1]["mode"], "helion")
+
+    @patch("model_cache_manager.cli.main.ensure_db")
+    @patch("model_cache_manager.cli.main.PruningService")
+    def test_prune_command_helion_mode(self, mock_prune_service, mock_ensure_db):
+        """Test prune command with helion mode."""
+        mock_ensure_db.return_value = None
+        mock_svc = MagicMock()
+        mock_svc.prune.return_value = MagicMock(pruned=1, reclaimed=0.5)
+        mock_svc.close.return_value = None
+        mock_prune_service.return_value = mock_svc
+
+        result = self.runner.invoke(app, [
+            "prune",
+            "--mode", "helion",
+            "--yes",
+        ])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_prune_service.assert_called_once_with(
+            cache_dir=None,
+            mode="helion",
+        )
+
+    @patch("model_cache_manager.cli.main.IndexService")
+    def test_index_command_helion_file_not_found(self, mock_index_service):
+        """Test index command when helion cache directory doesn't exist."""
+        mock_index_service.side_effect = FileNotFoundError(
+            "Helion cache directory not found"
+        )
+
+        result = self.runner.invoke(app, [
+            "index",
+            "--mode", "helion",
+            "--cache-dir", "/nonexistent/path",
+        ])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Helion cache directory not found", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mcm/model_cache_manager/tests/data/test_database.py
+++ b/mcm/model_cache_manager/tests/data/test_database.py
@@ -1,3 +1,4 @@
+# pylint: disable=duplicate-code
 """Test suite for the Database class."""
 
 import unittest

--- a/mcm/model_cache_manager/tests/data/test_helion_cache_repo.py
+++ b/mcm/model_cache_manager/tests/data/test_helion_cache_repo.py
@@ -120,7 +120,7 @@ class TestHelionCacheRepository(unittest.TestCase):
             results = list(repo.kernels())
 
         self.assertEqual(len(results), 1)
-        _cache_dir, triton_key, helion_hash, best_config, is_best, kernel = results[0]
+        _cache_dir, triton_key, helion_hash, _best_config, is_best, kernel = results[0]
         self.assertEqual(kernel.name, "_helion_add")
         self.assertEqual(triton_key, "KERNEL_A")
         self.assertEqual(helion_hash, "hash1")

--- a/mcm/model_cache_manager/tests/data/test_helion_cache_repo.py
+++ b/mcm/model_cache_manager/tests/data/test_helion_cache_repo.py
@@ -1,0 +1,209 @@
+"""
+Unit tests for the HelionCacheRepository.
+"""
+
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+from pathlib import Path
+import tempfile
+import shutil
+
+from model_cache_manager.data.cache_repo import HelionCacheRepository, HELION_KERNEL_PREFIX
+from model_cache_manager.models.kernel import Kernel
+
+
+class TestHelionCacheRepository(unittest.TestCase):
+    """Test suite for the HelionCacheRepository."""
+
+    def setUp(self):
+        """Set up test fixtures before each test method."""
+        self.temp_dir = Path(tempfile.mkdtemp())
+        self.cache_dir = self.temp_dir / "helion_cache"
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self):
+        """Clean up after each test method."""
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_init_with_existing_directory(self):
+        """Test initializing HelionCacheRepository with existing directory."""
+        repo = HelionCacheRepository(self.cache_dir)
+        self.assertEqual(repo.root, self.cache_dir)
+
+    def test_init_with_nonexistent_directory(self):
+        """Test initializing HelionCacheRepository with non-existent directory."""
+        nonexistent = self.temp_dir / "nonexistent"
+        with self.assertRaises(FileNotFoundError):
+            HelionCacheRepository(nonexistent)
+
+    def test_read_best_configs_empty(self):
+        """Test reading best configs when none exist."""
+        repo = HelionCacheRepository(self.cache_dir)
+        # pylint: disable=protected-access
+        configs = repo._read_best_configs()
+        self.assertEqual(configs, {})
+
+    def test_read_best_configs(self):
+        """Test reading best_config files."""
+        best_config_data = {
+            "config": '{"block_sizes": [32]}',
+            "backend_cache_key": "KERNEL_ABC",
+        }
+        (self.cache_dir / "abc123.best_config").write_text(
+            json.dumps(best_config_data)
+        )
+
+        repo = HelionCacheRepository(self.cache_dir)
+        # pylint: disable=protected-access
+        configs = repo._read_best_configs()
+        self.assertIn("KERNEL_ABC", configs)
+        helion_hash, raw = configs["KERNEL_ABC"]
+        self.assertEqual(helion_hash, "abc123")
+        self.assertIn("backend_cache_key", raw)
+
+    def test_read_best_configs_skips_invalid_json(self):
+        """Test that invalid JSON best_config files are skipped."""
+        (self.cache_dir / "bad.best_config").write_text("not json")
+        (self.cache_dir / "good.best_config").write_text(
+            json.dumps({"backend_cache_key": "KEY1"})
+        )
+
+        repo = HelionCacheRepository(self.cache_dir)
+        # pylint: disable=protected-access
+        configs = repo._read_best_configs()
+        self.assertEqual(len(configs), 1)
+        self.assertIn("KEY1", configs)
+
+    def test_read_best_configs_skips_missing_backend_key(self):
+        """Test that best_config without backend_cache_key is skipped."""
+        (self.cache_dir / "nokey.best_config").write_text(
+            json.dumps({"config": "test"})
+        )
+
+        repo = HelionCacheRepository(self.cache_dir)
+        # pylint: disable=protected-access
+        configs = repo._read_best_configs()
+        self.assertEqual(configs, {})
+
+    def test_kernels_empty(self):
+        """Test kernels with no triton directory."""
+        repo = HelionCacheRepository(self.cache_dir)
+        kernels = list(repo.kernels())
+        self.assertEqual(kernels, [])
+
+    def test_kernels_yields_helion_kernels(self):
+        """Test that kernels yields only _helion_ prefixed kernels."""
+        triton_dir = self.cache_dir / "triton" / "0"
+        triton_dir.mkdir(parents=True)
+        (triton_dir / "KERNEL_A").mkdir()
+
+        best_config_data = {"backend_cache_key": "KERNEL_A"}
+        (self.cache_dir / "hash1.best_config").write_text(
+            json.dumps(best_config_data)
+        )
+
+        repo = HelionCacheRepository(self.cache_dir)
+        with patch(
+            "model_cache_manager.data.cache_repo.iter_triton_kernels"
+        ) as mock_iter:
+            helion_kernel = MagicMock(spec=Kernel)
+            helion_kernel.name = "_helion_add"
+            helion_kernel.hash = "KERNEL_A"
+
+            regular_kernel = MagicMock(spec=Kernel)
+            regular_kernel.name = "triton_matmul"
+            regular_kernel.hash = "KERNEL_B"
+
+            mock_iter.return_value = [helion_kernel, regular_kernel]
+
+            results = list(repo.kernels())
+
+        self.assertEqual(len(results), 1)
+        _cache_dir, triton_key, helion_hash, best_config, is_best, kernel = results[0]
+        self.assertEqual(kernel.name, "_helion_add")
+        self.assertEqual(triton_key, "KERNEL_A")
+        self.assertEqual(helion_hash, "hash1")
+        self.assertTrue(is_best)
+
+    def test_kernels_is_best_false_when_no_match(self):
+        """Test that is_best is False when kernel hash doesn't match any best_config."""
+        triton_dir = self.cache_dir / "triton" / "0"
+        triton_dir.mkdir(parents=True)
+
+        best_config_data = {"backend_cache_key": "OTHER_KEY"}
+        (self.cache_dir / "hash1.best_config").write_text(
+            json.dumps(best_config_data)
+        )
+
+        repo = HelionCacheRepository(self.cache_dir)
+        with patch(
+            "model_cache_manager.data.cache_repo.iter_triton_kernels"
+        ) as mock_iter:
+            kernel = MagicMock(spec=Kernel)
+            kernel.name = "_helion_add"
+            kernel.hash = "UNMATCHED_KEY"
+            mock_iter.return_value = [kernel]
+
+            results = list(repo.kernels())
+
+        self.assertEqual(len(results), 1)
+        _, _, helion_hash, best_config, is_best, _ = results[0]
+        self.assertIsNone(helion_hash)
+        self.assertIsNone(best_config)
+        self.assertFalse(is_best)
+
+    def test_kernels_skips_kernel_with_no_name(self):
+        """Test that kernels with no name are skipped."""
+        (self.cache_dir / "triton" / "0").mkdir(parents=True)
+
+        repo = HelionCacheRepository(self.cache_dir)
+        with patch(
+            "model_cache_manager.data.cache_repo.iter_triton_kernels"
+        ) as mock_iter:
+            kernel = MagicMock(spec=Kernel)
+            kernel.name = None
+            kernel.hash = "K1"
+            mock_iter.return_value = [kernel]
+
+            results = list(repo.kernels())
+
+        self.assertEqual(results, [])
+
+    def test_kernels_multiple_best_configs(self):
+        """Test with multiple best_config files mapping to different kernels."""
+        (self.cache_dir / "triton" / "0").mkdir(parents=True)
+
+        (self.cache_dir / "h1.best_config").write_text(
+            json.dumps({"backend_cache_key": "K1"})
+        )
+        (self.cache_dir / "h2.best_config").write_text(
+            json.dumps({"backend_cache_key": "K2"})
+        )
+
+        repo = HelionCacheRepository(self.cache_dir)
+        with patch(
+            "model_cache_manager.data.cache_repo.iter_triton_kernels"
+        ) as mock_iter:
+            k1 = MagicMock(spec=Kernel)
+            k1.name = "_helion_op1"
+            k1.hash = "K1"
+
+            k2 = MagicMock(spec=Kernel)
+            k2.name = "_helion_op2"
+            k2.hash = "K2"
+
+            mock_iter.return_value = [k1, k2]
+            results = list(repo.kernels())
+
+        self.assertEqual(len(results), 2)
+        self.assertTrue(results[0][4])  # is_best
+        self.assertTrue(results[1][4])  # is_best
+
+    def test_helion_kernel_prefix_constant(self):
+        """Test that the prefix constant matches expected value."""
+        self.assertEqual(HELION_KERNEL_PREFIX, "_helion_")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mcm/model_cache_manager/tests/data/test_helion_cache_repo.py
+++ b/mcm/model_cache_manager/tests/data/test_helion_cache_repo.py
@@ -3,6 +3,7 @@ Unit tests for the HelionCacheRepository.
 """
 
 import json
+import os
 import unittest
 from unittest.mock import MagicMock, patch
 from pathlib import Path
@@ -21,9 +22,14 @@ class TestHelionCacheRepository(unittest.TestCase):
         self.temp_dir = Path(tempfile.mkdtemp())
         self.cache_dir = self.temp_dir / "helion_cache"
         self.cache_dir.mkdir(parents=True, exist_ok=True)
+        self._env_patch = patch.dict(
+            os.environ, {"TRITON_CACHE_DIR": ""}, clear=False
+        )
+        self._env_patch.start()
 
     def tearDown(self):
         """Clean up after each test method."""
+        self._env_patch.stop()
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
     def test_init_with_existing_directory(self):

--- a/mcm/model_cache_manager/tests/data/test_helion_database.py
+++ b/mcm/model_cache_manager/tests/data/test_helion_database.py
@@ -1,0 +1,329 @@
+"""
+Unit tests for the HelionDatabase and HelionKernelOrm.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch, Mock
+from pathlib import Path
+import time
+
+from model_cache_manager.data.database import HelionDatabase
+from model_cache_manager.data.db_models import HelionKernelOrm
+from model_cache_manager.models.kernel import Kernel, KernelFile
+from model_cache_manager.models.criteria import SearchCriteria
+from model_cache_manager.tests.test_utils import (
+    setup_kernel_orm_mock,
+    setup_sqlite_insert_mock,
+    setup_query_mock,
+    setup_tuple_mock,
+    setup_engine_and_session_mock,
+)
+
+
+def create_mock_kernel(
+    hash_val="test_hash",
+    name="_helion_add",
+    backend="cuda",
+    arch="89",
+    files=None,
+):
+    """Helper to create a mock Kernel object."""
+    if files is None:
+        f1 = Mock(spec=KernelFile)
+        f1.path = Path("/test/_helion_add.ptx")
+        f1.file_type = "ptx"
+        f1.size = 1024
+
+        f2 = Mock(spec=KernelFile)
+        f2.path = Path("/test/_helion_add.json")
+        f2.file_type = "json"
+        f2.size = 512
+
+        files = [f1, f2]
+
+    kernel = Mock(spec=Kernel)
+    kernel.hash = hash_val
+    kernel.name = name
+    kernel.backend = backend
+    kernel.arch = arch
+    kernel.files = files
+    kernel.metadata = {"test": "metadata"}
+    kernel.modified_time = time.time()
+    kernel.warp_size = 32
+    kernel.num_warps = 2
+    kernel.num_stages = 1
+    kernel.num_ctas = 1
+    kernel.maxnreg = None
+    kernel.cluster_dims = None
+    kernel.ptx_version = None
+    kernel.enable_fp_fusion = True
+    kernel.launch_cooperative_grid = False
+    kernel.supported_fp8_dtypes = []
+    kernel.deprecated_fp8_dtypes = []
+    kernel.default_dot_input_precision = "tf32"
+    kernel.allowed_dot_input_precisions = ["tf32", "ieee"]
+    kernel.max_num_imprecise_acc_default = 0
+    kernel.extern_libs = []
+    kernel.debug = False
+    kernel.backend_name = "cuda"
+    kernel.sanitize_overflow = False
+    kernel.triton_version = "3.3.0"
+    kernel.shared = 0
+    kernel.tmem_size = None
+    kernel.global_scratch_size = None
+    kernel.global_scratch_align = None
+    kernel.waves_per_eu = None
+    kernel.kpack = None
+    kernel.matrix_instr_nonkdim = None
+
+    return kernel
+
+
+class TestHelionKernelOrm(unittest.TestCase):
+    """Test suite for the HelionKernelOrm."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.mock_session = MagicMock()
+        self.mock_kernel = create_mock_kernel()
+
+    def test_upsert_from_dto(self):
+        """Test upsert_from_dto method."""
+        cache_dir = "/test/helion/cache"
+
+        with patch(
+            "model_cache_manager.data.db_models.sqlite_insert"
+        ) as mock_insert, patch(
+            "model_cache_manager.data.db_models.HelionKernelFileOrm"
+        ):
+            mock_stmt = MagicMock()
+            mock_insert.return_value = mock_stmt
+            mock_stmt.on_conflict_do_update.return_value = mock_stmt
+
+            HelionKernelOrm.upsert_from_dto(
+                self.mock_session,
+                self.mock_kernel,
+                cache_dir,
+                helion_hash="abc123",
+                best_config='{"backend_cache_key": "test_hash"}',
+                is_best=True,
+            )
+
+            mock_insert.assert_called_once_with(HelionKernelOrm)
+            self.mock_session.execute.assert_called_once()
+            self.mock_session.query.assert_called()  # pylint: disable=no-member
+
+    def test_get_helion_kernel_values(self):
+        """Test get_helion_kernel_values returns correct dict."""
+        values = HelionKernelOrm.get_helion_kernel_values(
+            self.mock_kernel, "/cache", "h1", '{"key": "val"}', True
+        )
+
+        self.assertEqual(values["triton_cache_key"], "test_hash")
+        self.assertEqual(values["cache_dir"], "/cache")
+        self.assertEqual(values["helion_hash"], "h1")
+        self.assertEqual(values["best_config"], '{"key": "val"}')
+        self.assertTrue(values["is_best"])
+        self.assertEqual(values["name"], "_helion_add")
+
+    def test_to_dict(self):
+        """Test to_dict maps kernel_metadata_json to metadata."""
+        orm = HelionKernelOrm()
+        orm.triton_cache_key = "key1"
+        orm.cache_dir = "/cache"
+        orm.kernel_metadata_json = {"test": "data"}
+
+        mock_col1 = MagicMock()
+        mock_col1.key = "triton_cache_key"
+        mock_col2 = MagicMock()
+        mock_col2.key = "cache_dir"
+        mock_col3 = MagicMock()
+        mock_col3.key = "kernel_metadata_json"
+
+        mock_table = MagicMock()
+        mock_table.columns = [mock_col1, mock_col2, mock_col3]
+        orm.__table__ = mock_table
+
+        result = orm.to_dict()
+
+        self.assertIn("metadata", result)
+        self.assertNotIn("kernel_metadata_json", result)
+        self.assertEqual(result["metadata"], {"test": "data"})
+
+
+class TestHelionDatabase(unittest.TestCase):
+    """Test suite for the HelionDatabase."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.mock_kernel = create_mock_kernel()
+
+    @patch("model_cache_manager.data.database.create_engine_and_session")
+    def test_init(self, mock_create_engine_session):
+        """Test HelionDatabase initialization."""
+        mock_engine, mock_session_local, _ = setup_engine_and_session_mock(
+            mock_create_engine_session
+        )
+
+        with patch("model_cache_manager.data.database_utils.ensure_schema") as mock_ensure:
+            db = HelionDatabase()
+
+            mock_create_engine_session.assert_called_once_with("helion")
+            self.assertEqual(db.engine, mock_engine)
+            self.assertEqual(db.SessionLocal, mock_session_local)
+            mock_ensure.assert_called_once_with(mock_engine)
+
+    @patch("model_cache_manager.data.database.create_engine_and_session")
+    def test_insert_kernel_success(self, mock_create_engine_session):
+        """Test successful kernel insertion."""
+        _, _, mock_session = setup_engine_and_session_mock(mock_create_engine_session)
+
+        with patch("model_cache_manager.data.database_utils.ensure_schema"), patch(
+            "model_cache_manager.data.database.HelionKernelOrm"
+        ) as mock_orm:
+            db = HelionDatabase()
+
+            db.insert_kernel(
+                self.mock_kernel, "/cache", "h1", '{"key": "val"}', True
+            )
+
+            mock_orm.upsert_from_dto.assert_called_once()
+            args = mock_orm.upsert_from_dto.call_args[0]
+            self.assertEqual(args[0], mock_session)
+            self.assertEqual(args[1], self.mock_kernel)
+            self.assertEqual(args[2], "/cache")
+            self.assertEqual(args[3], "h1")
+            self.assertEqual(args[4], '{"key": "val"}')
+            self.assertTrue(args[5])
+            mock_session.commit.assert_called_once()
+            mock_session.close.assert_called_once()
+
+    @patch("model_cache_manager.data.database.create_engine_and_session")
+    def test_bulk_insert_kernels_success(self, mock_create_engine_session):
+        """Test successful bulk kernel insertion."""
+        _, _, mock_session = setup_engine_and_session_mock(mock_create_engine_session)
+
+        class MockHelionFileOrm:  # pylint: disable=too-few-public-methods
+            """Mock ORM class."""
+            triton_cache_key = MagicMock()
+            cache_dir = MagicMock()
+
+        with patch("model_cache_manager.data.database_utils.ensure_schema"), patch(
+            "model_cache_manager.data.database.HelionKernelOrm"
+        ) as mock_orm, patch(
+            "model_cache_manager.data.database.HelionKernelFileOrm", MockHelionFileOrm
+        ), patch(
+            "model_cache_manager.data.database.sqlite_insert"
+        ) as mock_sqlite_insert, patch(
+            "model_cache_manager.data.database.tuple_"
+        ) as mock_tuple:
+            db = HelionDatabase()
+
+            setup_kernel_orm_mock(mock_orm)
+            setup_sqlite_insert_mock(mock_sqlite_insert)
+            setup_query_mock(mock_session)
+            setup_tuple_mock(mock_tuple)
+
+            kernels_data = [
+                (self.mock_kernel, "/cache", "h1", '{"key":"v"}', True),
+            ]
+
+            result = db.bulk_insert_kernels(kernels_data, batch_size=10)
+
+            self.assertEqual(result, 1)
+            mock_session.bulk_insert_mappings.assert_called_once()
+            file_dicts = mock_session.bulk_insert_mappings.call_args[0][1]
+            self.assertEqual(len(file_dicts), 2)
+            self.assertEqual(file_dicts[0]["triton_cache_key"], "test_hash")
+            self.assertEqual(file_dicts[0]["cache_dir"], "/cache")
+            mock_session.commit.assert_called_once()
+            mock_session.close.assert_called_once()
+
+    @patch("model_cache_manager.data.database.create_engine_and_session")
+    def test_bulk_insert_empty(self, mock_create_engine_session):
+        """Test bulk insert with empty list."""
+        setup_engine_and_session_mock(mock_create_engine_session)
+
+        with patch("model_cache_manager.data.database_utils.ensure_schema"):
+            db = HelionDatabase()
+            result = db.bulk_insert_kernels([])
+            self.assertEqual(result, 0)
+
+    @patch("model_cache_manager.data.database.create_engine_and_session")
+    def test_search_with_criteria(self, mock_create_engine_session):
+        """Test search method with criteria."""
+        _, _, mock_session = setup_engine_and_session_mock(mock_create_engine_session)
+
+        mock_orm_result = MagicMock()
+        mock_orm_result.to_dict.return_value = {
+            "triton_cache_key": "key1",
+            "name": "_helion_add",
+        }
+        mock_orm_result.is_best = True
+        mock_orm_result.best_config = None
+
+        mock_query = MagicMock()
+        mock_query.filter.return_value = mock_query
+        mock_query.order_by.return_value = mock_query
+        mock_query.all.return_value = [mock_orm_result]
+        mock_session.query.return_value = mock_query
+
+        with patch("model_cache_manager.data.database_utils.ensure_schema"), patch(
+            "model_cache_manager.data.database.HelionKernelOrm"
+        ):
+            db = HelionDatabase()
+            criteria = SearchCriteria(name="_helion_add")
+            results = db.search(criteria)
+
+            self.assertEqual(len(results), 1)
+            self.assertEqual(results[0]["triton_cache_key"], "key1")
+            self.assertTrue(results[0]["is_best"])
+            mock_session.close.assert_called_once()
+
+    @patch("model_cache_manager.data.database.create_engine_and_session")
+    def test_search_filters_by_only_best(self, mock_create_engine_session):
+        """Test search respects only_best filtering."""
+        _, _, mock_session = setup_engine_and_session_mock(mock_create_engine_session)
+
+        best_kernel = MagicMock()
+        best_kernel.to_dict.return_value = {"triton_cache_key": "k1"}
+        best_kernel.is_best = True
+        best_kernel.best_config = None
+
+        non_best_kernel = MagicMock()
+        non_best_kernel.to_dict.return_value = {"triton_cache_key": "k2"}
+        non_best_kernel.is_best = False
+        non_best_kernel.best_config = None
+
+        mock_query = MagicMock()
+        mock_query.filter.return_value = mock_query
+        mock_query.order_by.return_value = mock_query
+        mock_query.all.return_value = [best_kernel, non_best_kernel]
+        mock_session.query.return_value = mock_query
+
+        with patch("model_cache_manager.data.database_utils.ensure_schema"), patch(
+            "model_cache_manager.data.database.HelionKernelOrm"
+        ):
+            db = HelionDatabase()
+
+            results = db.search(SearchCriteria(only_best=True))
+            self.assertEqual(len(results), 1)
+            self.assertEqual(results[0]["triton_cache_key"], "k1")
+
+            results = db.search(SearchCriteria(only_best=False))
+            self.assertEqual(len(results), 1)
+            self.assertEqual(results[0]["triton_cache_key"], "k2")
+
+    @patch("model_cache_manager.data.database.create_engine_and_session")
+    def test_close(self, mock_create_engine_session):
+        """Test database close method."""
+        mock_engine, _, _ = setup_engine_and_session_mock(mock_create_engine_session)
+
+        with patch("model_cache_manager.data.database_utils.ensure_schema"):
+            db = HelionDatabase()
+            db.close()
+            mock_engine.dispose.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mcm/model_cache_manager/tests/data/test_helion_database.py
+++ b/mcm/model_cache_manager/tests/data/test_helion_database.py
@@ -1,17 +1,16 @@
+# pylint: disable=duplicate-code
 """
 Unit tests for the HelionDatabase and HelionKernelOrm.
 """
 
 import unittest
-from unittest.mock import MagicMock, patch, Mock
-from pathlib import Path
-import time
+from unittest.mock import MagicMock, patch
 
 from model_cache_manager.data.database import HelionDatabase
 from model_cache_manager.data.db_models import HelionKernelOrm
-from model_cache_manager.models.kernel import Kernel, KernelFile
 from model_cache_manager.models.criteria import SearchCriteria
 from model_cache_manager.tests.test_utils import (
+    create_mock_kernel,
     setup_kernel_orm_mock,
     setup_sqlite_insert_mock,
     setup_query_mock,
@@ -20,72 +19,13 @@ from model_cache_manager.tests.test_utils import (
 )
 
 
-def create_mock_kernel(
-    hash_val="test_hash",
-    name="_helion_add",
-    backend="cuda",
-    arch="89",
-    files=None,
-):
-    """Helper to create a mock Kernel object."""
-    if files is None:
-        f1 = Mock(spec=KernelFile)
-        f1.path = Path("/test/_helion_add.ptx")
-        f1.file_type = "ptx"
-        f1.size = 1024
-
-        f2 = Mock(spec=KernelFile)
-        f2.path = Path("/test/_helion_add.json")
-        f2.file_type = "json"
-        f2.size = 512
-
-        files = [f1, f2]
-
-    kernel = Mock(spec=Kernel)
-    kernel.hash = hash_val
-    kernel.name = name
-    kernel.backend = backend
-    kernel.arch = arch
-    kernel.files = files
-    kernel.metadata = {"test": "metadata"}
-    kernel.modified_time = time.time()
-    kernel.warp_size = 32
-    kernel.num_warps = 2
-    kernel.num_stages = 1
-    kernel.num_ctas = 1
-    kernel.maxnreg = None
-    kernel.cluster_dims = None
-    kernel.ptx_version = None
-    kernel.enable_fp_fusion = True
-    kernel.launch_cooperative_grid = False
-    kernel.supported_fp8_dtypes = []
-    kernel.deprecated_fp8_dtypes = []
-    kernel.default_dot_input_precision = "tf32"
-    kernel.allowed_dot_input_precisions = ["tf32", "ieee"]
-    kernel.max_num_imprecise_acc_default = 0
-    kernel.extern_libs = []
-    kernel.debug = False
-    kernel.backend_name = "cuda"
-    kernel.sanitize_overflow = False
-    kernel.triton_version = "3.3.0"
-    kernel.shared = 0
-    kernel.tmem_size = None
-    kernel.global_scratch_size = None
-    kernel.global_scratch_align = None
-    kernel.waves_per_eu = None
-    kernel.kpack = None
-    kernel.matrix_instr_nonkdim = None
-
-    return kernel
-
-
 class TestHelionKernelOrm(unittest.TestCase):
     """Test suite for the HelionKernelOrm."""
 
     def setUp(self):
         """Set up test fixtures."""
         self.mock_session = MagicMock()
-        self.mock_kernel = create_mock_kernel()
+        self.mock_kernel = create_mock_kernel(name="_helion_add", arch="89")
 
     def test_upsert_from_dto(self):
         """Test upsert_from_dto method."""
@@ -156,7 +96,7 @@ class TestHelionDatabase(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        self.mock_kernel = create_mock_kernel()
+        self.mock_kernel = create_mock_kernel(name="_helion_add", arch="89")
 
     @patch("model_cache_manager.data.database.create_engine_and_session")
     def test_init(self, mock_create_engine_session):

--- a/mcm/model_cache_manager/tests/data/test_vllm_database.py
+++ b/mcm/model_cache_manager/tests/data/test_vllm_database.py
@@ -1,82 +1,23 @@
+# pylint: disable=duplicate-code
 """
 Unit tests for the VllmDatabase and VllmKernelOrm.
 """
 
 import unittest
-from unittest.mock import MagicMock, patch, Mock
-from pathlib import Path
-import time
+from unittest.mock import MagicMock, patch
 
 from model_cache_manager.data.database import VllmDatabase
 from model_cache_manager.data.db_models import VllmKernelOrm, BaseKernelMixin
-from model_cache_manager.models.kernel import Kernel, KernelFile, VllmKernelMetadata
+from model_cache_manager.models.kernel import VllmKernelMetadata
 from model_cache_manager.models.criteria import SearchCriteria
 from model_cache_manager.tests.test_utils import (
+    create_mock_kernel,
     setup_kernel_orm_mock,
     setup_sqlite_insert_mock,
     setup_query_mock,
     setup_tuple_mock,
     setup_engine_and_session_mock,
 )
-
-
-def create_mock_kernel(
-    hash_val: str = "test_hash",
-    name: str = "test_kernel",
-    backend: str = "cuda",
-    arch: str = "80",
-    files: list = None,
-) -> Kernel:
-    """Helper to create a mock Kernel object."""
-    if files is None:
-        mock_file1 = Mock(spec=KernelFile)
-        mock_file1.path = Path("/test/kernel.ptx")
-        mock_file1.file_type = "ptx"
-        mock_file1.size = 1024
-
-        mock_file2 = Mock(spec=KernelFile)
-        mock_file2.path = Path("/test/kernel.json")
-        mock_file2.file_type = "json"
-        mock_file2.size = 512
-
-        files = [mock_file1, mock_file2]
-
-    kernel = Mock(spec=Kernel)
-    kernel.hash = hash_val
-    kernel.name = name
-    kernel.backend = backend
-    kernel.arch = arch
-    kernel.files = files
-    kernel.metadata = {"test": "metadata"}
-    kernel.modified_time = time.time()
-    kernel.warp_size = 32
-    kernel.num_warps = 4
-    kernel.num_stages = 2
-    kernel.num_ctas = 1
-    kernel.maxnreg = None
-    kernel.cluster_dims = None
-    kernel.ptx_version = "7.0"
-    kernel.enable_fp_fusion = True
-    kernel.launch_cooperative_grid = False
-    kernel.supported_fp8_dtypes = []
-    kernel.deprecated_fp8_dtypes = []
-    kernel.default_dot_input_precision = "fp16"
-    kernel.allowed_dot_input_precisions = ["fp16", "fp32"]
-    kernel.max_num_imprecise_acc_default = None
-    kernel.extern_libs = []
-    kernel.debug = False
-    kernel.backend_name = "cuda"
-    kernel.sanitize_overflow = False
-    kernel.triton_version = "3.3.0"
-    kernel.shared = 0
-    kernel.tmem_size = None
-    kernel.global_scratch_size = None
-    kernel.global_scratch_align = None
-    kernel.waves_per_eu = None
-    kernel.kpack = None
-    kernel.matrix_instr_nonkdim = None
-
-    return kernel
 
 
 class TestBaseKernelMixin(unittest.TestCase):
@@ -294,8 +235,8 @@ class TestVllmDatabase(unittest.TestCase):
                         "vllm_hash": "vllm_hash1",
                         "triton_cache_key": "test_hash",
                         "rank_x_y": "rank_0_0",
-                        "type": "json",
-                        "rel_path": "kernel.json",
+                        "type": "ttir",
+                        "rel_path": "kernel.ttir",
                         "size": 512,
                     },
                 ],

--- a/mcm/model_cache_manager/tests/services/test_helion_prune_service.py
+++ b/mcm/model_cache_manager/tests/services/test_helion_prune_service.py
@@ -117,7 +117,7 @@ class TestHelionPruningService(unittest.TestCase):
 
     @patch("model_cache_manager.services.prune.delete_ir_files_from_dirs")
     @patch("model_cache_manager.services.prune.get_kernel_directories")
-    def test_delete_ir_file_records_uses_helion_fk(
+    def test_delete_ir_file_records_uses_helion_fk(  # pylint: disable=no-member
         self, mock_get_dirs, mock_delete_ir
     ):
         """Test that _delete_ir_file_records queries by triton_cache_key for helion."""

--- a/mcm/model_cache_manager/tests/services/test_helion_prune_service.py
+++ b/mcm/model_cache_manager/tests/services/test_helion_prune_service.py
@@ -125,6 +125,12 @@ class TestHelionPruningService(unittest.TestCase):
         mock_delete_ir.return_value = (512, ["_helion_add.ttir", "_helion_add.llir"])
 
         mock_session = MagicMock()
+        mock_query = MagicMock()
+        mock_session.query.return_value = mock_query
+        mock_filter = MagicMock()
+        mock_query.filter.return_value = mock_filter
+        mock_filter.all.return_value = []
+
         mock_kernel_record = MagicMock()
         mock_kernel_record.files = []
         mock_session.get.return_value = mock_kernel_record
@@ -135,8 +141,8 @@ class TestHelionPruningService(unittest.TestCase):
         self.svc._delete_kernel_unified(identifier, mock_session, ir_only=True)
 
         mock_session.query.assert_called()
-        filter_call = mock_session.query.return_value.filter.call_args
-        filter_args = filter_call[0]
+        mock_query.filter.assert_called()
+        filter_args = mock_query.filter.call_args[0]
 
         found_triton_key_filter = False
         found_cache_dir_filter = False

--- a/mcm/model_cache_manager/tests/services/test_helion_prune_service.py
+++ b/mcm/model_cache_manager/tests/services/test_helion_prune_service.py
@@ -10,6 +10,7 @@ import logging
 from model_cache_manager.services.prune import PruningService, PruneStats
 from model_cache_manager.models.criteria import SearchCriteria
 from model_cache_manager.utils.mcm_constants import IR_EXTS, MODE_HELION
+from model_cache_manager.utils.utils import create_kernel_identifier
 
 from model_cache_manager.data.cache_repo import HelionCacheRepository
 from model_cache_manager.data.database import HelionDatabase
@@ -64,7 +65,7 @@ class TestHelionPruningService(unittest.TestCase):
         return_value=2048,
     )
     @patch("model_cache_manager.services.prune.Confirm.ask")
-    def test_prune_ir_only_helion(self, mock_confirm, mock_delete):
+    def test_prune_ir_only_helion(self, _mock_confirm, mock_delete):
         """Test IR-only prune for helion kernels."""
         criteria = SearchCriteria()
         self.mock_db.search.return_value = [self.helion_kernel]
@@ -79,7 +80,6 @@ class TestHelionPruningService(unittest.TestCase):
         self.mock_db.estimate_space.assert_called_once_with(
             ["KERNEL_ABC"], IR_EXTS
         )
-        mock_confirm.assert_not_called()
 
         self.assertEqual(mock_delete.call_count, 1)
         call_args = mock_delete.call_args[0]
@@ -94,7 +94,7 @@ class TestHelionPruningService(unittest.TestCase):
         return_value=4096,
     )
     @patch("model_cache_manager.services.prune.Confirm.ask")
-    def test_prune_full_helion(self, mock_confirm, mock_delete):
+    def test_prune_full_helion(self, _mock_confirm, mock_delete):
         """Test full prune for helion kernels."""
         criteria = SearchCriteria()
         self.mock_db.search.return_value = [self.helion_kernel]
@@ -129,7 +129,6 @@ class TestHelionPruningService(unittest.TestCase):
         mock_kernel_record.files = []
         mock_session.get.return_value = mock_kernel_record
 
-        from model_cache_manager.utils.utils import create_kernel_identifier
         identifier = create_kernel_identifier(mode=MODE_HELION, hash="KERNEL_ABC")
 
         # pylint: disable=protected-access
@@ -170,7 +169,6 @@ class TestHelionPruningService(unittest.TestCase):
         mock_kernel_record = MagicMock()
         mock_session.get.return_value = mock_kernel_record
 
-        from model_cache_manager.utils.utils import create_kernel_identifier
         identifier = create_kernel_identifier(mode=MODE_HELION, hash="KERNEL_ABC")
 
         # pylint: disable=protected-access

--- a/mcm/model_cache_manager/tests/services/test_helion_prune_service.py
+++ b/mcm/model_cache_manager/tests/services/test_helion_prune_service.py
@@ -1,0 +1,183 @@
+"""
+Unit tests for PruningService with Helion mode.
+"""
+
+import unittest
+from unittest.mock import patch, MagicMock
+from pathlib import Path
+import logging
+
+from model_cache_manager.services.prune import PruningService, PruneStats
+from model_cache_manager.models.criteria import SearchCriteria
+from model_cache_manager.utils.mcm_constants import IR_EXTS, MODE_HELION
+
+from model_cache_manager.data.cache_repo import HelionCacheRepository
+from model_cache_manager.data.database import HelionDatabase
+
+logging.disable(logging.CRITICAL)
+
+
+class TestHelionPruningService(unittest.TestCase):
+    """Test suite for PruningService in Helion mode."""
+
+    def setUp(self):
+        """Set up test fixtures before each test method."""
+        self.mock_repo = MagicMock(spec=HelionCacheRepository)
+        self.mock_repo.root = Path("/fake/helion/cache")
+
+        self.mock_db = MagicMock(spec=HelionDatabase)
+
+        self.patch_repo = patch(
+            "model_cache_manager.strategies.helion_strategy.HelionCacheRepository",
+            return_value=self.mock_repo,
+        )
+        self.patch_db = patch(
+            "model_cache_manager.strategies.helion_strategy.HelionDatabase",
+            return_value=self.mock_db,
+        )
+
+        self.patch_repo.start()
+        self.patch_db.start()
+
+        self.svc = PruningService(
+            cache_dir=Path("/fake/helion/cache"), mode=MODE_HELION
+        )
+
+        self.helion_kernel = {
+            "triton_cache_key": "KERNEL_ABC",
+            "name": "_helion_add",
+            "backend": "cuda",
+            "arch": "89",
+            "helion_hash": "abc123",
+            "best_config": '{"backend_cache_key": "KERNEL_ABC"}',
+            "is_best": True,
+            "total_size": 2048,
+        }
+
+    def tearDown(self):
+        """Clean up after each test method."""
+        self.patch_repo.stop()
+        self.patch_db.stop()
+
+    @patch(
+        "model_cache_manager.services.prune.PruningService._delete_kernel_unified",
+        return_value=2048,
+    )
+    @patch("model_cache_manager.services.prune.Confirm.ask")
+    def test_prune_ir_only_helion(self, mock_confirm, mock_delete):
+        """Test IR-only prune for helion kernels."""
+        criteria = SearchCriteria()
+        self.mock_db.search.return_value = [self.helion_kernel]
+        self.mock_db.estimate_space.return_value = 1024
+
+        mock_session = MagicMock()
+        self.mock_db.get_session.return_value.__enter__.return_value = mock_session
+
+        stats = self.svc.prune(criteria, delete_ir_only=True, auto_confirm=True)
+
+        self.mock_db.search.assert_called_once_with(criteria)
+        self.mock_db.estimate_space.assert_called_once_with(
+            ["KERNEL_ABC"], IR_EXTS
+        )
+        mock_confirm.assert_not_called()
+
+        self.assertEqual(mock_delete.call_count, 1)
+        call_args = mock_delete.call_args[0]
+        self.assertEqual(call_args[0].hash_key, "KERNEL_ABC")
+        self.assertTrue(call_args[2])  # ir_only=True
+
+        self.assertIsInstance(stats, PruneStats)
+        self.assertEqual(stats.pruned, 1)
+
+    @patch(
+        "model_cache_manager.services.prune.PruningService._delete_kernel_unified",
+        return_value=4096,
+    )
+    @patch("model_cache_manager.services.prune.Confirm.ask")
+    def test_prune_full_helion(self, mock_confirm, mock_delete):
+        """Test full prune for helion kernels."""
+        criteria = SearchCriteria()
+        self.mock_db.search.return_value = [self.helion_kernel]
+        self.mock_db.estimate_space.return_value = 4096
+
+        mock_session = MagicMock()
+        self.mock_db.get_session.return_value.__enter__.return_value = mock_session
+
+        stats = self.svc.prune(criteria, delete_ir_only=False, auto_confirm=True)
+
+        self.mock_db.estimate_space.assert_called_once_with(
+            ["KERNEL_ABC"], None
+        )
+        self.assertEqual(mock_delete.call_count, 1)
+        call_args = mock_delete.call_args[0]
+        self.assertFalse(call_args[2])  # ir_only=False
+
+        self.assertIsInstance(stats, PruneStats)
+        self.assertEqual(stats.pruned, 1)
+
+    @patch("model_cache_manager.services.prune.delete_ir_files_from_dirs")
+    @patch("model_cache_manager.services.prune.get_kernel_directories")
+    def test_delete_ir_file_records_uses_helion_fk(
+        self, mock_get_dirs, mock_delete_ir
+    ):
+        """Test that _delete_ir_file_records queries by triton_cache_key for helion."""
+        mock_get_dirs.return_value = [Path("/fake/triton/0/KERNEL_ABC")]
+        mock_delete_ir.return_value = (512, ["_helion_add.ttir", "_helion_add.llir"])
+
+        mock_session = MagicMock()
+        mock_kernel_record = MagicMock()
+        mock_kernel_record.files = []
+        mock_session.get.return_value = mock_kernel_record
+
+        from model_cache_manager.utils.utils import create_kernel_identifier
+        identifier = create_kernel_identifier(mode=MODE_HELION, hash="KERNEL_ABC")
+
+        # pylint: disable=protected-access
+        self.svc._delete_kernel_unified(identifier, mock_session, ir_only=True)
+
+        mock_session.query.assert_called()
+        filter_call = mock_session.query.return_value.filter.call_args
+        filter_args = filter_call[0]
+
+        found_triton_key_filter = False
+        found_cache_dir_filter = False
+        for arg in filter_args:
+            arg_str = str(arg)
+            if "triton_cache_key" in arg_str:
+                found_triton_key_filter = True
+            if "cache_dir" in arg_str:
+                found_cache_dir_filter = True
+
+        self.assertTrue(
+            found_triton_key_filter,
+            "Filter should use triton_cache_key for helion mode"
+        )
+        self.assertTrue(
+            found_cache_dir_filter,
+            "Filter should include cache_dir for helion mode"
+        )
+
+    @patch("model_cache_manager.services.prune.delete_kernel_directories")
+    @patch("model_cache_manager.services.prune.get_kernel_directories")
+    def test_full_delete_removes_kernel_record(
+        self, mock_get_dirs, mock_delete_dirs
+    ):
+        """Test that full prune deletes the kernel record from DB."""
+        mock_get_dirs.return_value = [Path("/fake/triton/0/KERNEL_ABC")]
+        mock_delete_dirs.return_value = 4096
+
+        mock_session = MagicMock()
+        mock_kernel_record = MagicMock()
+        mock_session.get.return_value = mock_kernel_record
+
+        from model_cache_manager.utils.utils import create_kernel_identifier
+        identifier = create_kernel_identifier(mode=MODE_HELION, hash="KERNEL_ABC")
+
+        # pylint: disable=protected-access
+        self.svc._delete_kernel_unified(identifier, mock_session, ir_only=False)
+
+        mock_session.delete.assert_called_once_with(mock_kernel_record)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mcm/model_cache_manager/tests/test_utils.py
+++ b/mcm/model_cache_manager/tests/test_utils.py
@@ -158,6 +158,31 @@ def create_mock_kernel(
     mock_kernel.modified_time = modified_time
     mock_kernel.cache_dir = cache_dir
     mock_kernel.files = files
+    mock_kernel.warp_size = 32
+    mock_kernel.num_warps = 4
+    mock_kernel.num_stages = 2
+    mock_kernel.num_ctas = 1
+    mock_kernel.maxnreg = None
+    mock_kernel.cluster_dims = None
+    mock_kernel.ptx_version = None
+    mock_kernel.enable_fp_fusion = True
+    mock_kernel.launch_cooperative_grid = False
+    mock_kernel.supported_fp8_dtypes = []
+    mock_kernel.deprecated_fp8_dtypes = []
+    mock_kernel.default_dot_input_precision = "fp16"
+    mock_kernel.allowed_dot_input_precisions = ["fp16", "fp32"]
+    mock_kernel.max_num_imprecise_acc_default = None
+    mock_kernel.extern_libs = []
+    mock_kernel.debug = False
+    mock_kernel.backend_name = "cuda"
+    mock_kernel.sanitize_overflow = False
+    mock_kernel.shared = 0
+    mock_kernel.tmem_size = None
+    mock_kernel.global_scratch_size = None
+    mock_kernel.global_scratch_align = None
+    mock_kernel.waves_per_eu = None
+    mock_kernel.kpack = None
+    mock_kernel.matrix_instr_nonkdim = None
 
     for attr, value in kwargs.items():
         setattr(mock_kernel, attr, value)

--- a/mcm/model_cache_manager/tests/utils/test_cache_mode_detection.py
+++ b/mcm/model_cache_manager/tests/utils/test_cache_mode_detection.py
@@ -8,7 +8,12 @@ import shutil
 from pathlib import Path
 
 from model_cache_manager.utils.utils import detect_cache_mode
-from model_cache_manager.utils.mcm_constants import MODE_TRITON, MODE_VLLM, MODE_VLLM_LEGACY
+from model_cache_manager.utils.mcm_constants import (
+    MODE_TRITON,
+    MODE_VLLM,
+    MODE_VLLM_LEGACY,
+    MODE_HELION,
+)
 
 
 class TestCacheModeDetection(unittest.TestCase):  # pylint: disable=too-many-public-methods
@@ -329,6 +334,48 @@ class TestCacheModeDetection(unittest.TestCase):  # pylint: disable=too-many-pub
 
         mode = detect_cache_mode(cache_dir)
         self.assertEqual(mode, MODE_VLLM)
+
+    def test_detect_helion_cache_structure(self):
+        """Test detection of Helion cache structure."""
+        cache_dir = self.temp_dir / "helion"
+        cache_dir.mkdir()
+
+        # best_config file
+        (cache_dir / "abc123.best_config").write_text('{"backend_cache_key": "KEY"}')
+
+        # triton directory with a device subdir and kernel
+        kernel_dir = cache_dir / "triton" / "0" / "KEY"
+        kernel_dir.mkdir(parents=True)
+
+        mode = detect_cache_mode(cache_dir)
+        self.assertEqual(mode, MODE_HELION)
+
+    def test_detect_helion_no_best_config(self):
+        """Test that triton/ alone without best_config is not helion."""
+        cache_dir = self.temp_dir / "helion_no_cfg"
+        kernel_dir = cache_dir / "triton" / "0" / "KEY"
+        kernel_dir.mkdir(parents=True)
+
+        mode = detect_cache_mode(cache_dir)
+        self.assertEqual(mode, MODE_TRITON)
+
+    def test_detect_helion_no_triton_dir(self):
+        """Test that best_config alone without triton/ is not helion."""
+        cache_dir = self.temp_dir / "helion_no_triton"
+        cache_dir.mkdir()
+        (cache_dir / "abc123.best_config").write_text('{"backend_cache_key": "KEY"}')
+
+        mode = detect_cache_mode(cache_dir)
+        self.assertEqual(mode, MODE_TRITON)
+
+    def test_detect_helion_best_config_is_directory(self):
+        """Test that a directory ending in .best_config doesn't trigger helion."""
+        cache_dir = self.temp_dir / "helion_dir_cfg"
+        (cache_dir / "abc.best_config").mkdir(parents=True)
+        (cache_dir / "triton" / "0").mkdir(parents=True)
+
+        mode = detect_cache_mode(cache_dir)
+        self.assertEqual(mode, MODE_TRITON)
 
 
 if __name__ == "__main__":

--- a/mcm/model_cache_manager/tests/utils/test_utils_functions.py
+++ b/mcm/model_cache_manager/tests/utils/test_utils_functions.py
@@ -12,6 +12,7 @@ from model_cache_manager.utils.utils import (
     get_temp_extraction_dir,
     _find_kernel_dirs_in_aot_cache,
     find_vllm_kernel_dirs,
+    find_helion_kernel_dirs,
 )
 
 
@@ -257,6 +258,70 @@ class TestFindVllmKernelDirsAot(unittest.TestCase):
             self.temp_dir, "nonexistent", "KERNEL_A"
         )
         self.assertEqual(result, [])
+
+
+class TestFindHelionKernelDirs(unittest.TestCase):
+    """Tests for find_helion_kernel_dirs function."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.temp_dir = Path(tempfile.mkdtemp())
+
+    def tearDown(self):
+        """Clean up test fixtures."""
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_finds_kernel_in_helion_cache(self):
+        """Test finding a kernel in the helion triton layout."""
+        kernel_dir = self.temp_dir / "triton" / "0" / "KERNEL_ABC"
+        kernel_dir.mkdir(parents=True)
+
+        result = find_helion_kernel_dirs(self.temp_dir, "KERNEL_ABC")
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].name, "KERNEL_ABC")
+
+    def test_returns_empty_when_no_triton_dir(self):
+        """Test returns empty list when triton/ doesn't exist."""
+        self.temp_dir.mkdir(exist_ok=True)
+        result = find_helion_kernel_dirs(self.temp_dir, "KERNEL_ABC")
+        self.assertEqual(result, [])
+
+    def test_returns_empty_when_kernel_missing(self):
+        """Test returns empty list when kernel hash doesn't exist."""
+        (self.temp_dir / "triton" / "0" / "OTHER").mkdir(parents=True)
+        result = find_helion_kernel_dirs(self.temp_dir, "NONEXISTENT")
+        self.assertEqual(result, [])
+
+    def test_finds_kernel_across_devices(self):
+        """Test finding a kernel under multiple device subdirs."""
+        (self.temp_dir / "triton" / "0" / "KERNEL_ABC").mkdir(parents=True)
+        (self.temp_dir / "triton" / "1" / "KERNEL_ABC").mkdir(parents=True)
+
+        result = find_helion_kernel_dirs(self.temp_dir, "KERNEL_ABC")
+        self.assertEqual(len(result), 2)
+
+    @patch.dict("os.environ", {"TRITON_CACHE_DIR": ""})
+    def test_ignores_empty_triton_cache_dir_env(self):
+        """Test that an empty TRITON_CACHE_DIR falls back to cache_dir/triton."""
+        (self.temp_dir / "triton" / "0" / "KERNEL_X").mkdir(parents=True)
+
+        result = find_helion_kernel_dirs(self.temp_dir, "KERNEL_X")
+        self.assertEqual(len(result), 1)
+
+    def test_triton_cache_dir_env_takes_precedence(self):
+        """Test that TRITON_CACHE_DIR is used when set."""
+        alt_triton = self.temp_dir / "alt_triton"
+        (alt_triton / "0" / "KERNEL_Y").mkdir(parents=True)
+
+        # Also create under cache_dir/triton — should NOT be found
+        (self.temp_dir / "triton" / "0" / "KERNEL_Z").mkdir(parents=True)
+
+        with patch.dict("os.environ", {"TRITON_CACHE_DIR": str(alt_triton)}):
+            result = find_helion_kernel_dirs(self.temp_dir, "KERNEL_Y")
+            self.assertEqual(len(result), 1)
+
+            result_z = find_helion_kernel_dirs(self.temp_dir, "KERNEL_Z")
+            self.assertEqual(len(result_z), 0)
 
 
 if __name__ == "__main__":

--- a/mcm/model_cache_manager/utils/config.py
+++ b/mcm/model_cache_manager/utils/config.py
@@ -4,11 +4,23 @@ Configuration settings for the Model Cache Manager.
 This module provides configuration settings including paths and defaults.
 """
 
+import getpass
 import platform
 import os
 from pathlib import Path
 from pydantic import Field
 from pydantic_settings import BaseSettings
+
+
+def _default_helion_cache_dir() -> Path:
+    helion_env = os.getenv("HELION_CACHE_DIR")
+    if helion_env:
+        return Path(helion_env)
+    triton_env = os.getenv("TRITON_CACHE_DIR")
+    if triton_env:
+        return Path(triton_env)
+    user = getpass.getuser()
+    return Path("/tmp") / f"torchinductor_{user}" / "helion"
 
 
 class Settings(BaseSettings):
@@ -26,6 +38,9 @@ class Settings(BaseSettings):
     )
     model_cache_dir_vllm: Path = Field(
         default_factory=lambda: Path.home() / ".cache" / "vllm"
+    )
+    model_cache_dir_helion: Path = Field(
+        default_factory=_default_helion_cache_dir
     )
     data_dir: Path = Field(
         default_factory=lambda: Path.home() / (

--- a/mcm/model_cache_manager/utils/config.py
+++ b/mcm/model_cache_manager/utils/config.py
@@ -19,7 +19,10 @@ def _default_helion_cache_dir() -> Path:
     triton_env = os.getenv("TRITON_CACHE_DIR")
     if triton_env:
         return Path(triton_env)
-    user = getpass.getuser()
+    try:
+        user = getpass.getuser()
+    except KeyError:
+        user = str(os.getuid())
     return Path("/tmp") / f"torchinductor_{user}" / "helion"
 
 

--- a/mcm/model_cache_manager/utils/config.py
+++ b/mcm/model_cache_manager/utils/config.py
@@ -16,9 +16,6 @@ def _default_helion_cache_dir() -> Path:
     helion_env = os.getenv("HELION_CACHE_DIR")
     if helion_env:
         return Path(helion_env)
-    triton_env = os.getenv("TRITON_CACHE_DIR")
-    if triton_env:
-        return Path(triton_env)
     try:
         user = getpass.getuser()
     except KeyError:

--- a/mcm/model_cache_manager/utils/mcm_constants.py
+++ b/mcm/model_cache_manager/utils/mcm_constants.py
@@ -4,4 +4,5 @@ IR_EXTS = {".ttir", ".ttgir", ".llir"}
 MODE_VLLM = "vllm"
 MODE_VLLM_LEGACY = "vllm-legacy"
 MODE_TRITON = "triton"
+MODE_HELION = "helion"
 ARTIFACT_COMPILE_RANGE_PREFIX = "artifact_compile_range_"

--- a/mcm/model_cache_manager/utils/paths.py
+++ b/mcm/model_cache_manager/utils/paths.py
@@ -6,19 +6,26 @@ This module provides functions to get standard paths used by the application.
 
 from pathlib import Path
 from model_cache_manager.utils.config import settings
-from model_cache_manager.utils.mcm_constants import MODE_TRITON, MODE_VLLM, MODE_VLLM_LEGACY
+from model_cache_manager.utils.mcm_constants import (
+    MODE_TRITON,
+    MODE_VLLM,
+    MODE_VLLM_LEGACY,
+    MODE_HELION,
+)
 
 
 def get_cache_dir(mode: str = MODE_TRITON) -> Path:
     """
-    Get the path to the Triton cache directory.
+    Get the path to the cache directory for the given mode.
 
     Returns:
-        Path to the Triton cache directory.
+        Path to the cache directory.
     """
 
     if mode in (MODE_VLLM, MODE_VLLM_LEGACY):
         return settings.model_cache_dir_vllm
+    if mode == MODE_HELION:
+        return settings.model_cache_dir_helion
     return settings.model_cache_dir
 
 

--- a/mcm/model_cache_manager/utils/strategy_factory.py
+++ b/mcm/model_cache_manager/utils/strategy_factory.py
@@ -3,7 +3,7 @@ Strategy factory for creating appropriate strategy instances based on mode.
 """
 
 # pylint: disable=relative-beyond-top-level
-from ..utils.mcm_constants import MODE_VLLM, MODE_VLLM_LEGACY
+from ..utils.mcm_constants import MODE_VLLM, MODE_VLLM_LEGACY, MODE_HELION
 
 
 def create_strategy(mode: str):
@@ -11,7 +11,7 @@ def create_strategy(mode: str):
     Factory function to create the appropriate strategy based on mode.
 
     Args:
-        mode: The mode string (MODE_VLLM, MODE_VLLM_LEGACY, or default)
+        mode: The mode string (MODE_VLLM, MODE_VLLM_LEGACY, MODE_HELION, or default)
 
     Returns:
         An instance of the appropriate strategy class
@@ -21,9 +21,12 @@ def create_strategy(mode: str):
     from ..strategies.vllm_strategy import VllmStrategy
     from ..strategies.vllm_legacy_strategy import VllmLegacyStrategy
     from ..strategies.triton_strategy import TritonStrategy
+    from ..strategies.helion_strategy import HelionStrategy
 
     if mode == MODE_VLLM:
         return VllmStrategy()
     if mode == MODE_VLLM_LEGACY:
         return VllmLegacyStrategy()
+    if mode == MODE_HELION:
+        return HelionStrategy()
     return TritonStrategy()

--- a/mcm/model_cache_manager/utils/utils.py
+++ b/mcm/model_cache_manager/utils/utils.py
@@ -2,6 +2,7 @@
 Utilities.
 """
 
+import os
 import re
 import logging
 import shutil
@@ -16,6 +17,7 @@ from model_cache_manager.utils.mcm_constants import (
     MODE_TRITON,
     MODE_VLLM,
     MODE_VLLM_LEGACY,
+    MODE_HELION,
     ARTIFACT_COMPILE_RANGE_PREFIX,
 )
 
@@ -245,6 +247,29 @@ def _has_vllm_aot_cache_structure(cache_dir: Path) -> bool:
     return False
 
 
+def _has_helion_cache_structure(cache_dir: Path) -> bool:
+    """Check if directory has Helion cache structure.
+
+    Helion caches have ``*.best_config`` files alongside a ``triton/``
+    directory at the root level.
+    """
+    if not cache_dir.is_dir():
+        return False
+
+    has_best_config = False
+    has_triton = False
+
+    for item in cache_dir.iterdir():
+        if item.is_file() and item.name.endswith(".best_config"):
+            has_best_config = True
+        elif item.is_dir() and item.name == "triton":
+            has_triton = True
+        if has_best_config and has_triton:
+            return True
+
+    return False
+
+
 def detect_cache_mode(cache_dir: Path) -> str:
     """
     Auto-detect cache mode based on directory structure.
@@ -254,31 +279,24 @@ def detect_cache_mode(cache_dir: Path) -> str:
 
     Returns:
         'vllm' for new vLLM structure, 'vllm-legacy' for old vLLM structure,
-        'triton' otherwise
+        'helion' for Helion structure, 'triton' otherwise
     """
     if not cache_dir.exists():
         return MODE_TRITON
 
-    # Check for new vLLM cache structure (with backbone/artifact_compile_range_* directories)
-    if _has_vllm_cache_structure(cache_dir):
+    # Check for vLLM cache structures (new or AOT)
+    if _has_vllm_cache_structure(cache_dir) or _has_vllm_aot_cache_structure(cache_dir):
         return MODE_VLLM
 
-    # Check for vLLM AOT compile structure (inductor_cache/triton/)
-    if _has_vllm_aot_cache_structure(cache_dir):
-        return MODE_VLLM
+    # Check for Helion cache structure (*.best_config + triton/)
+    if _has_helion_cache_structure(cache_dir):
+        return MODE_HELION
 
     # Check for legacy vLLM cache structure (with direct triton_cache)
     if _has_vllm_legacy_cache_structure(cache_dir):
         return MODE_VLLM_LEGACY
 
-    # Check for direct triton cache structure
-    # Look for triton kernel files in the directory
-    for item in cache_dir.rglob("*.json"):
-        # Triton kernels typically have .json metadata files
-        if item.parent.name.startswith("triton_"):
-            return MODE_TRITON
-
-    return MODE_TRITON  # Default to triton mode
+    return MODE_TRITON
 
 
 # Kernel operations utilities
@@ -481,6 +499,33 @@ def find_vllm_kernel_dirs(
     return kernel_dirs
 
 
+def _resolve_helion_triton_dir(cache_dir: Path) -> Optional[Path]:
+    """Resolve the triton directory for a Helion cache.
+
+    When ``TRITON_CACHE_DIR`` is set the triton kernels live there directly;
+    otherwise they are under ``cache_dir/triton/``.
+    """
+    triton_cache_env = os.getenv("TRITON_CACHE_DIR")
+    if triton_cache_env:
+        candidate = Path(triton_cache_env)
+        if candidate.is_dir():
+            return candidate
+    candidate = cache_dir / "triton"
+    if candidate.is_dir():
+        return candidate
+    return None
+
+
+def find_helion_kernel_dirs(
+    cache_dir: Path, triton_cache_key: str
+) -> List[Path]:
+    """Find kernel directories for Helion cache structure."""
+    triton_dir = _resolve_helion_triton_dir(cache_dir)
+    if triton_dir is None:
+        return []
+    return _find_kernel_dirs_in_triton(triton_dir, triton_cache_key)
+
+
 def get_kernel_directories(
     cache_dir: Path, mode: str, identifier: KernelIdentifier
 ) -> List[Path]:
@@ -494,7 +539,6 @@ def get_kernel_directories(
     if mode == MODE_VLLM:
         if identifier.vllm_hash is None:
             raise ValueError("vllm_hash cannot be None for VLLM mode")
-        # Use artifact_compile_range and triton_subpath if available for precise lookup
         return find_vllm_kernel_dirs(
             cache_dir,
             identifier.vllm_hash,
@@ -502,6 +546,8 @@ def get_kernel_directories(
             identifier.artifact_compile_range,
             identifier.triton_subpath,
         )
+    if mode == MODE_HELION:
+        return find_helion_kernel_dirs(cache_dir, identifier.hash_key)
     return [cache_dir / identifier.hash_key]
 
 
@@ -578,6 +624,11 @@ def extract_identifiers_from_groups(
                         mode=mode,
                         vllm_hash=kernel_dict["vllm_hash"],
                         triton_cache_key=kernel_dict["triton_cache_key"],
+                    )
+                elif mode == MODE_HELION:
+                    identifier = create_kernel_identifier(
+                        mode=mode,
+                        hash=kernel_dict["triton_cache_key"],
                     )
                 else:
                     identifier = create_kernel_identifier(

--- a/mcm/model_cache_manager/utils/utils.py
+++ b/mcm/model_cache_manager/utils/utils.py
@@ -250,24 +250,21 @@ def _has_vllm_aot_cache_structure(cache_dir: Path) -> bool:
 def _has_helion_cache_structure(cache_dir: Path) -> bool:
     """Check if directory has Helion cache structure.
 
-    Helion caches have ``*.best_config`` files alongside a ``triton/``
-    directory at the root level.
+    Helion caches have ``*.best_config`` files in ``cache_dir`` and triton
+    kernels available either under ``cache_dir/triton/`` or via
+    ``TRITON_CACHE_DIR`` in a split-cache layout.
     """
     if not cache_dir.is_dir():
         return False
 
-    has_best_config = False
-    has_triton = False
+    has_best_config = any(
+        item.is_file() and item.name.endswith(".best_config")
+        for item in cache_dir.iterdir()
+    )
+    if not has_best_config:
+        return False
 
-    for item in cache_dir.iterdir():
-        if item.is_file() and item.name.endswith(".best_config"):
-            has_best_config = True
-        elif item.is_dir() and item.name == "triton":
-            has_triton = True
-        if has_best_config and has_triton:
-            return True
-
-    return False
+    return resolve_helion_triton_dir(cache_dir) is not None
 
 
 def detect_cache_mode(cache_dir: Path) -> str:

--- a/mcm/model_cache_manager/utils/utils.py
+++ b/mcm/model_cache_manager/utils/utils.py
@@ -499,7 +499,7 @@ def find_vllm_kernel_dirs(
     return kernel_dirs
 
 
-def _resolve_helion_triton_dir(cache_dir: Path) -> Optional[Path]:
+def resolve_helion_triton_dir(cache_dir: Path) -> Optional[Path]:
     """Resolve the triton directory for a Helion cache.
 
     When ``TRITON_CACHE_DIR`` is set the triton kernels live there directly;
@@ -520,7 +520,7 @@ def find_helion_kernel_dirs(
     cache_dir: Path, triton_cache_key: str
 ) -> List[Path]:
     """Find kernel directories for Helion cache structure."""
-    triton_dir = _resolve_helion_triton_dir(cache_dir)
+    triton_dir = resolve_helion_triton_dir(cache_dir)
     if triton_dir is None:
         return []
     return _find_kernel_dirs_in_triton(triton_dir, triton_cache_key)


### PR DESCRIPTION
  ## Summary      
  - Add `MODE_HELION` with full strategy/repository/database/ORM stack,
    following the existing pattern for triton and vLLM modes                                                                                                               
  - Auto-detect Helion caches by the presence of `*.best_config` files
    alongside a `triton/` directory                                                                                                                                        
  - Cache dir resolution: `HELION_CACHE_DIR` → `TRITON_CACHE_DIR` →                                                                                                        
    `/tmp/torchinductor_<user>/helion`                                                                                                                                     
  - Only `_helion_`-prefixed kernels are indexed; `is_best` is computed                                                                                                    
    from `backend_cache_key` in best_config files                                                                                                                          
  - Simplify `detect_cache_mode()` (merge vLLM checks, drop redundant
    triton rglob)                                                                                                                                                          
                  
  ## Test plan                                                                                                                                                             
  - [x] `pytest model_cache_manager/tests/` — 136 tests pass
  - [x] Helion detection: structure present, missing best_config, missing                                                                                                  
    triton/, best_config-as-directory                                                                                                                                      
  - [x] Helion kernel lookup: default triton/, TRITON_CACHE_DIR override,                                                                                                  
    missing kernel, multi-device                                                                                                                                           
  - [x] Helion repository: best_config reading, _helion_ prefix filtering,                                                                                                 
    is_best computation, multiple best_configs                                                                                                                             
  - [x] `mcm index --mode helion --cache-dir <helion_cache>` against a                                                                                                     
    real Helion cache 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full Helion cache mode: detection, config, CLI support, repository, database, strategy, and pruning integration.
  * CLI shows Helion metadata and "best" indicators; env-driven Helion cache dir selection.

* **Tests**
  * Comprehensive unit and integration tests for Helion detection, repository, utilities, database, CLI, and pruning behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->